### PR TITLE
kx: deploy our genesis resources

### DIFF
--- a/docker/deployment/Dockerfile
+++ b/docker/deployment/Dockerfile
@@ -1,3 +1,5 @@
 FROM docker.io/oasislabs/testnet:latest
 
 ADD . /ekiden
+# hack for web3-client hardcoded paths
+RUN ln -s /ekiden/res /resources

--- a/docker/deployment/build-images-inner.sh
+++ b/docker/deployment/build-images-inner.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash -ex
 
 # Our development image sets up the PATH in .bashrc. Source that.
 PS1='\$'
@@ -25,6 +25,7 @@ mkdir -p target/docker-deployment/context/bin target/docker-deployment/context/l
 ln target/contract/ekiden-key-manager.so target/docker-deployment/context/lib/evm-key-manager.so
 ln target/contract/evm.so target/docker-deployment/context/lib
 ln target/contract/evm.mrenclave target/docker-deployment/context/res
+cp -r resources/genesis target/docker-deployment/context/res
 ln target/debug/web3-client target/docker-deployment/context/bin
 ln docker/deployment/Dockerfile target/docker-deployment/context/Dockerfile
 tar cvzhf target/docker-deployment/context.tar.gz -C target/docker-deployment/context .


### PR DESCRIPTION
puts it in res, but the builder makes a symlink from /resources