### PR TITLE
Use log macros rather than println

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ evm-api = { path = "./api" }
 ekiden-core = { git = "https://github.com/oasislabs/ekiden", branch = "master" }
 ekiden-trusted = { git = "https://github.com/oasislabs/ekiden", branch = "master" }
 protobuf = "~1.4"
+log = "0.4"
 
 [build-dependencies]
 ekiden-tools = { git = "https://github.com/oasislabs/ekiden", branch = "master" }

--- a/src/evm/mod.rs
+++ b/src/evm/mod.rs
@@ -37,11 +37,11 @@ fn handle_fire<P: Patch>(vm: &mut SeqTransactionVM<P>, state: &StateDb) {
         match vm.fire() {
             Ok(()) => break,
             Err(RequireError::Account(address)) => {
-                println!("> Require Account: {:x}", address);
+                trace!("> Require Account: {:x}", address);
                 let addr_str = address.hex();
                 let commit = match state.accounts.get(&addr_str) {
                     Some(b) => {
-                        println!("  -> Found account");
+                        trace!("  -> Found account");
                         AccountCommitment::Full {
                             nonce: U256::from_dec_str(b.get_nonce()).unwrap(),
                             address: address,
@@ -50,14 +50,14 @@ fn handle_fire<P: Patch>(vm: &mut SeqTransactionVM<P>, state: &StateDb) {
                         }
                     }
                     None => {
-                        println!("  -> Nonexistent");
+                        trace!("  -> Nonexistent");
                         AccountCommitment::Nonexist(address)
                     }
                 };
                 vm.commit_account(commit).unwrap();
             }
             Err(RequireError::AccountStorage(address, index)) => {
-                println!("> Require Account Storage: {:x} @ {:x}", address, index);
+                trace!("> Require Account Storage: {:x} @ {:x}", address, index);
                 let addr_str = address.hex();
                 let index_str = format!("{:x}", index);
 
@@ -72,7 +72,7 @@ fn handle_fire<P: Patch>(vm: &mut SeqTransactionVM<P>, state: &StateDb) {
                     None => M256::zero(),
                 };
 
-                println!("  -> {:?}", value);
+                trace!("  -> {:?}", value);
                 vm.commit_account(AccountCommitment::Storage {
                     address: address,
                     index: index,
@@ -80,25 +80,25 @@ fn handle_fire<P: Patch>(vm: &mut SeqTransactionVM<P>, state: &StateDb) {
                 }).unwrap();
             }
             Err(RequireError::AccountCode(address)) => {
-                println!("> Require Account Code: {:x}", address);
+                trace!("> Require Account Code: {:x}", address);
                 let addr_str = address.hex();
                 let commit = match state.accounts.get(&addr_str) {
                     Some(b) => {
-                        println!("  -> Found code");
+                        trace!("  -> Found code");
                         AccountCommitment::Code {
                             address: address,
                             code: Rc::new(read_hex(b.get_code()).unwrap()),
                         }
                     }
                     None => {
-                        println!("  -> Nonexistent");
+                        trace!("  -> Nonexistent");
                         AccountCommitment::Nonexist(address)
                     }
                 };
                 vm.commit_account(commit).unwrap();
             }
             Err(RequireError::Blockhash(number)) => {
-                println!("> Require Blockhash @ {:x}", number);
+                trace!("> Require Blockhash @ {:x}", number);
                 // TODO: maintain block state (including blockhash)
                 let result = match number.as_u32() {
                     4976641 => H256::from_str(
@@ -338,11 +338,11 @@ pub fn fire_transaction<P: Patch>(
 
     handle_fire(&mut vm, &state);
 
-    println!("    VM returned: {:?}", vm.status());
-    println!("    VM out: {:?}", vm.out());
+    trace!("    VM returned: {:?}", vm.status());
+    trace!("    VM out: {:?}", vm.out());
 
     for account in vm.accounts() {
-        println!("        {:?}", account);
+        trace!("        {:?}", account);
     }
 
     vm

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,13 @@
 #![feature(use_extern_macros)]
 #![feature(alloc)]
 
+#[macro_use]
+mod logger;
 mod evm;
 mod miner;
 mod util;
 
+extern crate log;
 extern crate protobuf;
 
 extern crate alloc;
@@ -97,7 +100,7 @@ fn inject_accounts(request: &InjectAccountsRequest) -> Result<InjectAccountsResp
 // TODO: secure this method so it can't be called by any client.
 #[cfg(debug_assertions)]
 fn init_genesis_block(_block: &InitStateRequest) -> Result<InitStateResponse> {
-    println!("*** Init genesis block");
+    info!("*** Init genesis block");
     let state = StateDb::new();
 
     if state.genesis_initialized.is_present() {
@@ -178,8 +181,8 @@ fn get_block_by_number(request: &BlockRequest) -> Result<BlockResponse> {
 }
 
 fn get_transaction_record(request: &TransactionRecordRequest) -> Result<TransactionRecordResponse> {
-    println!("*** Get transaction record");
-    println!("Hash: {:?}", request.get_hash());
+    info!("*** Get transaction record");
+    info!("Hash: {:?}", request.get_hash());
 
     let hash = normalize_hex_str(request.get_hash());
 
@@ -194,8 +197,8 @@ fn get_transaction_record(request: &TransactionRecordRequest) -> Result<Transact
 }
 
 fn get_account_balance(request: &AccountRequest) -> Result<AccountBalanceResponse> {
-    println!("*** Get account balance");
-    println!("Address: {:?}", request.get_address());
+    info!("*** Get account balance");
+    info!("Address: {:?}", request.get_address());
 
     let address = normalize_hex_str(request.get_address());
     let balance = get_balance(address);
@@ -207,8 +210,8 @@ fn get_account_balance(request: &AccountRequest) -> Result<AccountBalanceRespons
 }
 
 fn get_account_nonce(request: &AccountRequest) -> Result<AccountNonceResponse> {
-    println!("*** Get account nonce");
-    println!("Address: {:?}", request.get_address());
+    info!("*** Get account nonce");
+    info!("Address: {:?}", request.get_address());
 
     let address = normalize_hex_str(request.get_address());
     let nonce = get_nonce(address);
@@ -220,8 +223,8 @@ fn get_account_nonce(request: &AccountRequest) -> Result<AccountNonceResponse> {
 }
 
 fn get_account_code(request: &AccountRequest) -> Result<AccountCodeResponse> {
-    println!("*** Get account code");
-    println!("Address: {:?}", request.get_address());
+    info!("*** Get account code");
+    info!("Address: {:?}", request.get_address());
 
     let address = normalize_hex_str(request.get_address());
     let code = get_code_string(address);
@@ -235,8 +238,8 @@ fn get_account_code(request: &AccountRequest) -> Result<AccountCodeResponse> {
 fn execute_raw_transaction(
     request: &ExecuteRawTransactionRequest,
 ) -> Result<ExecuteTransactionResponse> {
-    println!("*** Execute raw transaction");
-    println!("Data: {:?}", request.get_data());
+    info!("*** Execute raw transaction");
+    info!("Data: {:?}", request.get_data());
 
     let value = match read_hex(request.get_data()) {
         Ok(val) => val,
@@ -264,8 +267,8 @@ fn execute_raw_transaction(
 }
 
 fn simulate_transaction(request: &ExecuteTransactionRequest) -> Result<ExecuteTransactionResponse> {
-    println!("*** Simulate transaction");
-    println!("Transaction: {:?}", request.get_transaction());
+    info!("*** Simulate transaction");
+    info!("Transaction: {:?}", request.get_transaction());
 
     let valid = match unsigned_to_valid(request.get_transaction()) {
         Ok(val) => val,
@@ -282,7 +285,7 @@ fn simulate_transaction(request: &ExecuteTransactionRequest) -> Result<ExecuteTr
     }
 
     let result = to_hex(&vm.out());
-    println!("*** Result: {:?}", result);
+    trace!("*** Result: {:?}", result);
 
     response.set_result(result);
 
@@ -297,8 +300,8 @@ fn simulate_transaction(request: &ExecuteTransactionRequest) -> Result<ExecuteTr
 fn debug_execute_unsigned_transaction(
     request: &ExecuteTransactionRequest,
 ) -> Result<ExecuteTransactionResponse> {
-    println!("*** Execute transaction");
-    println!("Transaction: {:?}", request.get_transaction());
+    info!("*** Execute transaction");
+    info!("Transaction: {:?}", request.get_transaction());
 
     let valid = match unsigned_to_valid(request.get_transaction()) {
         Ok(val) => val,

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,0 +1,60 @@
+/// temporary fix: define macros that match the log crate interface but simply use println directly
+/// once log is enabled for enclaves, we can simply swap in the real macros
+
+// max log level defined at compile-time
+pub const STATIC_MAX_LEVEL: ::log::LevelFilter = ::log::LevelFilter::Trace;
+
+macro_rules! log {
+    (target: $target:expr, $lvl:expr, $($arg:tt)+) => ({
+        let lvl = $lvl;
+        if lvl <= $crate::logger::STATIC_MAX_LEVEL {
+            println!($($arg)+)
+        }
+    });
+    ($lvl:expr, $($arg:tt)+) => (log!(target: module_path!(), $lvl, $($arg)+))
+}
+
+macro_rules! error {
+    (target: $target:expr, $($arg:tt)*) => (
+        log!(target: $target, $crate::log::Level::Error, $($arg)*);
+    );
+    ($($arg:tt)*) => (
+        log!($crate::log::Level::Error, $($arg)*);
+    )
+}
+
+macro_rules! warn {
+    (target: $target:expr, $($arg:tt)*) => (
+        log!(target: $target, $crate::log::Level::Warn, $($arg)*);
+    );
+    ($($arg:tt)*) => (
+        log!($crate::log::Level::Warn, $($arg)*);
+    )
+}
+
+macro_rules! info {
+    (target: $target:expr, $($arg:tt)*) => (
+        log!(target: $target, $crate::log::Level::Info, $($arg)*);
+    );
+    ($($arg:tt)*) => (
+        log!($crate::log::Level::Info, $($arg)*);
+    )
+}
+
+macro_rules! debug {
+    (target: $target:expr, $($arg:tt)*) => (
+        log!(target: $target, $crate::log::Level::Debug, $($arg)*);
+    );
+    ($($arg:tt)*) => (
+        log!($crate::log::Level::Debug, $($arg)*);
+    )
+}
+
+macro_rules! trace {
+    (target: $target:expr, $($arg:tt)*) => (
+        log!(target: $target, $crate::log::Level::Trace, $($arg)*);
+    );
+    ($($arg:tt)*) => (
+        log!($crate::log::Level::Trace, $($arg)*);
+    )
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -21,8 +21,8 @@ pub fn to_valid<P: Patch>(
     transaction: &Transaction,
 ) -> ::std::result::Result<ValidTransaction, PreExecutionError> {
     // debugging
-    println!("*** Validate block transaction");
-    println!("Data: {:?}", transaction);
+    debug!("*** Validate block transaction");
+    debug!("Data: {:?}", transaction);
 
     // check caller signature
     let caller = match transaction.caller() {


### PR DESCRIPTION
Replace direct println logging with macros that duplicate the log crate interface but use println under the hood. Max log level defined at compile-time by a constant in logging.rs. Once log is enabled for contracts, we can simply swap in the real macros from the log crate.