### PR TITLE
kx: longer epoch

### DIFF
--- a/testnet/kx/kx.yaml
+++ b/testnet/kx/kx.yaml
@@ -38,7 +38,7 @@ spec:
             - --time-source
             - mock
             - --mock-epoch-interval
-            - "60"
+            - "3600"
 ---
 kind: Service
 apiVersion: v1


### PR DESCRIPTION
**right now**, with no extra features: let's lengthen it to 1 hour on contract-evm.