### PR TITLE
Updates to web3 client to facilitate testing

### DIFF
--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -95,7 +95,7 @@ fn main() {
                 .long("threads")
                 .help("Number of threads to use for HTTP server.")
                 .default_value("1")
-                .takes_value(true)
+                .takes_value(true),
         )
         .get_matches();
 

--- a/client/src/rpc/mod.rs
+++ b/client/src/rpc/mod.rs
@@ -314,11 +314,7 @@ build_rpc_trait! {
     }
 }
 
-pub fn rpc_loop(
-    client: Arc<evm::Client>,
-    addr: &SocketAddr,
-    num_threads: usize,
-) {
+pub fn rpc_loop(client: Arc<evm::Client>, addr: &SocketAddr, num_threads: usize) {
     let rpc = serves::MinerEthereumRPC::new(client.clone());
     let filter = serves::MinerFilterRPC::new(client);
     let debug = serves::MinerDebugRPC::new();


### PR DESCRIPTION
- [x] Add command-line argument to client for number of threads in HTTP server
- [x] Remove logger initialization, as it is now done in a client-utils macro