### PR TITLE
kx: fix client-dummy connections

### DIFF
--- a/testnet/kx/kx.yaml
+++ b/testnet/kx/kx.yaml
@@ -161,8 +161,8 @@ spec:
             - -c
             - >-
               exec web3-client
-              --entity-registry-client-host $(EKIDEN_TOKEN_NODE_DUMMY_SERVICE_HOST)
-              --entity-registry-client-port $(EKIDEN_TOKEN_NODE_DUMMY_SERVICE_PORT_DUMMY_GRPC)
-              --scheduler-client-host $(EKIDEN_TOKEN_NODE_DUMMY_SERVICE_HOST)
-              --scheduler-client-port $(EKIDEN_TOKEN_NODE_DUMMY_SERVICE_PORT_DUMMY_GRPC)
+              --entity-registry-client-host $(EVM_NODE_DUMMY_SERVICE_HOST)
+              --entity-registry-client-port $(EVM_NODE_DUMMY_SERVICE_PORT_DUMMY_GRPC)
+              --scheduler-client-host $(EVM_NODE_DUMMY_SERVICE_HOST)
+              --scheduler-client-port $(EVM_NODE_DUMMY_SERVICE_PORT_DUMMY_GRPC)
               --mr-enclave $$(cat ekiden/res/evm.mrenclave)


### PR DESCRIPTION
copy paste error. it was connecting to the token node dummy
fixes https://github.com/oasislabs/ekiden/issues/382