### PR TITLE
Use build-enclave rather than build-contract

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,15 +40,15 @@ jobs:
             --branch master
             --debug
             ekiden-node-dummy
-      # Build the contract.
-      - run: cargo ekiden build-contract --output-identity
-      # Build the benchmarking version of the contract (in release mode)
+      # Build the runtime.
+      - run: cargo ekiden build-enclave --output-identity
+      # Build the benchmarking version of the runtime (in release mode)
       - run: mkdir target_benchmark
       - run:
           name: Build the benchmarking version of the runtime
           environment:
             CARGO_TARGET_DIR: target_benchmark
-          command: cargo ekiden build-contract --output-identity --cargo-addendum feature.benchmark.addendum --target-dir target_benchmark --release -- --features "benchmark"
+          command: cargo ekiden build-enclave --output-identity --cargo-addendum feature.benchmark.addendum --target-dir target_benchmark --release -- --features "benchmark"
       # Run the runtime tests.
       - run:
           name: Run the runtime tests

--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ If you later need to update them to a new version use the `--force` flag to upda
 
 To build the runtime simply run:
 ```bash
-$ cargo ekiden build-contract
+$ cargo ekiden build-enclave
 ```
 
-The built contract will be stored under `target/contract/runtime-ethereum.so`.
+The built enclave will be stored under `target/enclave/runtime-ethereum.so`.
 
 ## Running the runtime
 
@@ -70,7 +70,7 @@ $ ekiden-compute \
     --entity-ethereum-address 0000000000000000000000000000000000000000 \
     --batch-storage immediate_remote \
     --port <port number> \
-    target/contract/runtime-ethereum.so
+    target/enclave/runtime-ethereum.so
 ```
 
 After starting the nodes, to manually advance the epoch in the shared dummy node:
@@ -78,11 +78,11 @@ After starting the nodes, to manually advance the epoch in the shared dummy node
 $ ekiden-node-dummy-controller set-epoch --epoch 1
 ```
 
-The contract's compute node will listen on `127.0.0.1` (loopback), TCP port `9001` by default.
+The compute node will listen on `127.0.0.1` (loopback), TCP port `9001` by default.
 
 Development notes:
 
-* If you are developing a contract and changing things, be sure to either use the `--no-persist-identity` flag or remove the referenced enclave identity file (e.g., `/tmp/runtime-ethereum.identity.pb`). Otherwise the compute node will fail to start as it will be impossible to unseal the old identity.
+* If you are changing things, be sure to either use the `--no-persist-identity` flag or remove the referenced enclave identity file (e.g., `/tmp/runtime-ethereum.identity.pb`). Otherwise the compute node will fail to start as it will be impossible to unseal the old identity.
 
 ## Building the web3 gateway
 
@@ -103,10 +103,10 @@ For `<mr-enclave>` you can use the value reported when starting the compute node
 
 To build the benchmarking version of the runtime (release build, logging suppressed, nonce checking disabled):
 ```bash
-$ CARGO_TARGET_DIR=target_benchmark cargo ekiden build-contract --output-identity --cargo-addendum feature.benchmark.addendum --target-dir target_benchmark --release -- --features "benchmark"
+$ CARGO_TARGET_DIR=target_benchmark cargo ekiden build-enclave --output-identity --cargo-addendum feature.benchmark.addendum --target-dir target_benchmark --release -- --features "benchmark"
 ```
 
-The built contract will be stored under `target_benchmark/contract/runtime-ethereum.so`.
+The built enclave will be stored under `target_benchmark/enclave/runtime-ethereum.so`.
 
 Release builds of `benchmark`, `gateway`, `genesis`, and `playback` are also used for benchmarking. To build, for each component:
 ```bash

--- a/docker/deployment/build-images-inner.sh
+++ b/docker/deployment/build-images-inner.sh
@@ -16,13 +16,13 @@ fi
 
 # Build all Ekiden binaries and resources.
 CARGO_TARGET_DIR=target cargo install --force --git https://github.com/oasislabs/ekiden --branch master ekiden-tools
-cargo ekiden build-contract --output-identity --release
+cargo ekiden build-enclave --output-identity --release
 (cd gateway && CARGO_BUILD_TARGET_DIR=../target cargo build --release)
 
 # Package all binaries and resources.
 mkdir -p target/docker-deployment/context/bin target/docker-deployment/context/lib target/docker-deployment/context/res
-ln target/contract/runtime-ethereum.so target/docker-deployment/context/lib
-ln target/contract/runtime-ethereum.mrenclave target/docker-deployment/context/res
+ln target/enclave/runtime-ethereum.so target/docker-deployment/context/lib
+ln target/enclave/runtime-ethereum.mrenclave target/docker-deployment/context/res
 cp -r resources/genesis target/docker-deployment/context/res
 ln target/release/gateway target/docker-deployment/context/bin
 ln docker/deployment/Dockerfile target/docker-deployment/context/Dockerfile

--- a/genesis/Cargo.toml
+++ b/genesis/Cargo.toml
@@ -8,7 +8,6 @@ clap = "2.29.1"
 ethereum-types = { git = "https://github.com/ekiden/primitives", branch = "ekiden" }
 filebuffer = "0.4.0"
 futures = "0.1.18"
-grpcio = "0.2.2"
 hex = "0.3.1"
 log = "0.4"
 pretty_env_logger = "0.2"

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -9,7 +9,6 @@ use ethereum_types::{Address, H256, U256};
 extern crate filebuffer;
 extern crate futures;
 use futures::future::Future;
-extern crate grpcio;
 extern crate hex;
 extern crate log;
 use log::{debug, log};

--- a/scripts/benchmarks/genesis.sh
+++ b/scripts/benchmarks/genesis.sh
@@ -44,7 +44,7 @@ run_compute_node_default() {
         --batch-storage immediate_remote \
         --port ${port} \
         ${extra_args} \
-        ${WORKDIR}/target_benchmark/contract/runtime-ethereum.so &> compute${id}.log &
+        ${WORKDIR}/target_benchmark/enclave/runtime-ethereum.so &> compute${id}.log &
 }
 
 run_compute_node_storage_multilayer() {
@@ -70,7 +70,7 @@ run_compute_node_storage_multilayer() {
         --storage-multilayer-aws-table-name test \
         --port ${port} \
         ${extra_args} \
-        ${WORKDIR}/target_benchmark/contract/runtime-ethereum.so &> compute${id}.log &
+        ${WORKDIR}/target_benchmark/enclave/runtime-ethereum.so &> compute${id}.log &
 }
 
 run_test() {
@@ -98,7 +98,7 @@ run_test() {
     # Start genesis state injector.
     echo "Starting genesis state injector."
     ${WORKDIR}/genesis/target/release/genesis \
-        --mr-enclave $(cat ${WORKDIR}/target_benchmark/contract/runtime-ethereum.mrenclave) \
+        --mr-enclave $(cat ${WORKDIR}/target_benchmark/enclave/runtime-ethereum.mrenclave) \
 	${WORKDIR}/genesis/state-999999.json &
     genesis_pid=$!
 

--- a/scripts/benchmarks/playback_e2e.sh
+++ b/scripts/benchmarks/playback_e2e.sh
@@ -32,7 +32,7 @@ run_compute_node() {
 	--entity-ethereum-address 0000000000000000000000000000000000000000 \
         --port ${port} \
         ${extra_args} \
-        ${WORKDIR}/target_benchmark/contract/runtime-ethereum.so &> compute${id}.log &
+        ${WORKDIR}/target_benchmark/enclave/runtime-ethereum.so &> compute${id}.log &
 }
 
 run_test() {
@@ -59,7 +59,7 @@ run_test() {
     # Start genesis state injector.
     echo "Starting genesis state injector."
     ${WORKDIR}/genesis/target/release/genesis \
-        --mr-enclave $(cat target_benchmark/contract/runtime-ethereum.mrenclave) \
+        --mr-enclave $(cat target_benchmark/enclave/runtime-ethereum.mrenclave) \
 	${WORKDIR}/genesis/state-9999.json &> genesis.log &
     genesis_pid=$!
 
@@ -69,7 +69,7 @@ run_test() {
     # Run the client.
     echo "Starting web3 gateway."
     gateway/target/release/gateway \
-        --mr-enclave $(cat ${WORKDIR}/target_benchmark/contract/runtime-ethereum.mrenclave) \
+        --mr-enclave $(cat ${WORKDIR}/target_benchmark/enclave/runtime-ethereum.mrenclave) \
         --threads 100 &> ${WORKDIR}/gateway.log &
     sleep 5
 

--- a/scripts/benchmarks/web3_microbenchmark.sh
+++ b/scripts/benchmarks/web3_microbenchmark.sh
@@ -32,7 +32,7 @@ run_compute_node() {
 	--entity-ethereum-address 0000000000000000000000000000000000000000 \
         --port ${port} \
         ${extra_args} \
-        ${WORKDIR}/target_benchmark/contract/runtime-ethereum.so &> compute${id}.log &
+        ${WORKDIR}/target_benchmark/enclave/runtime-ethereum.so &> compute${id}.log &
 }
 
 run_test() {
@@ -60,7 +60,7 @@ run_test() {
     # committee to be elected and connects to the leader.
     echo "Starting web3 gateway."
     gateway/target/release/gateway \
-        --mr-enclave $(cat $WORKDIR/target_benchmark/contract/runtime-ethereum.mrenclave) \
+        --mr-enclave $(cat $WORKDIR/target_benchmark/enclave/runtime-ethereum.mrenclave) \
         --threads 100 &> gateway.log &
     sleep 2
 

--- a/scripts/gateway.sh
+++ b/scripts/gateway.sh
@@ -31,7 +31,7 @@ run_compute_node() {
 	--entity-ethereum-address 0000000000000000000000000000000000000000 \
 	--port ${port} \
         ${extra_args} \
-        ${WORKDIR}/target/contract/runtime-ethereum.so &> compute${id}.log &
+        ${WORKDIR}/target/enclave/runtime-ethereum.so &> compute${id}.log &
 }
 
 run_test() {
@@ -59,7 +59,7 @@ run_test() {
     # committee to be elected and connects to the leader.
     echo "Starting web3 gateway."
     gateway/target/debug/gateway \
-        --mr-enclave $(cat $WORKDIR/target/contract/runtime-ethereum.mrenclave) \
+        --mr-enclave $(cat $WORKDIR/target/enclave/runtime-ethereum.mrenclave) \
         --threads 100 &> gateway.log &
     gateway_pid=$!
 

--- a/scripts/test-e2e.sh
+++ b/scripts/test-e2e.sh
@@ -31,7 +31,7 @@ run_compute_node() {
 	--entity-ethereum-address 0000000000000000000000000000000000000000 \
 	--port ${port} \
         ${extra_args} \
-        ${WORKDIR}/target/contract/runtime-ethereum.so &> compute${id}.log &
+        ${WORKDIR}/target/enclave/runtime-ethereum.so &> compute${id}.log &
 }
 
 run_test() {
@@ -59,7 +59,7 @@ run_test() {
     # committee to be elected and connects to the leader.
     echo "Starting web3 gateway."
     target/debug/gateway \
-        --mr-enclave $(cat $WORKDIR/target/contract/runtime-ethereum.mrenclave) \
+        --mr-enclave $(cat $WORKDIR/target/enclave/runtime-ethereum.mrenclave) \
         --threads 100 \
         --prometheus-metrics-addr 0.0.0.0:3000 \
         --prometheus-mode pull &> gateway.log &


### PR DESCRIPTION
The tool for building enclaves was renamed to `build-enclave`: https://github.com/oasislabs/ekiden/pull/665. The build artifacts directory was changed to `target/enclave`.