### PR TITLE
Remove signer from contract client constructor

### DIFF
--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -88,8 +88,6 @@ use std::sync::Arc;
 use clap::ArgMatches;
 
 use ekiden_contract_client::create_contract_client;
-use ekiden_core::{bytes::B256, ring::signature::Ed25519KeyPair, signature::InMemorySigner,
-                  untrusted};
 use ekiden_di::Container;
 use ethereum_api::with_api;
 
@@ -99,20 +97,12 @@ with_api! {
     create_contract_client!(runtime_ethereum, ethereum_api, api);
 }
 
-/// Generate client key pair.
-fn create_key_pair() -> Arc<InMemorySigner> {
-    let key_pair =
-        Ed25519KeyPair::from_seed_unchecked(untrusted::Input::from(&B256::random())).unwrap();
-    Arc::new(InMemorySigner::new(key_pair))
-}
-
 pub fn start(
     args: ArgMatches,
     mut container: Container,
     num_threads: usize,
 ) -> Result<RunningClient, String> {
-    let signer = create_key_pair();
-    let client = contract_client!(signer, runtime_ethereum, args, container);
+    let client = contract_client!(runtime_ethereum, args, container);
 
     run::execute(client, num_threads)
 }

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -65,11 +65,6 @@ fn strip_0x<'a>(hex: &'a str) -> &'a str {
 }
 
 fn main() {
-    let seed = ekiden_core::bytes::B256::random();
-    let seed_input = ekiden_core::untrusted::Input::from(&seed);
-    let key_pair =
-        ekiden_core::ring::signature::Ed25519KeyPair::from_seed_unchecked(seed_input).unwrap();
-    let signer = std::sync::Arc::new(ekiden_core::signature::InMemorySigner::new(key_pair));
     let known_components = client_utils::components::create_known_components();
     let args = default_app!()
         .args(&known_components.get_arguments())
@@ -84,7 +79,7 @@ fn main() {
         .build_with_arguments(&args)
         .expect("failed to initialize component container");
 
-    let client = contract_client!(signer, ethereum, args, container);
+    let client = contract_client!(ethereum, args, container);
 
     let state_path = args.value_of("exported_state").unwrap();
     debug!("Parsing state JSON");


### PR DESCRIPTION
Due to a recent change in Ekiden core libraries, the client no longer requires a signer to be passed.