### PR TITLE
playback: the 0x that gateways crave

### DIFF
--- a/playback/src/main.rs
+++ b/playback/src/main.rs
@@ -51,7 +51,7 @@ fn get_transactions_from_blocks(blocks_path: &str, max_num_transactions: usize) 
         // https://github.com/paritytech/parity/blob/v1.9.7/ethcore/src/views/block.rs#L101
         let transactions = block.at(1);
         for transaction in transactions.iter() {
-            ret.push(hex::encode(transaction.as_raw()));
+            ret.push(format!("0x{}", hex::encode(transaction.as_raw())));
             num_transactions += 1;
             if max_num_transactions != 0 && num_transactions >= max_num_transactions {
                 break 'outer;


### PR DESCRIPTION
the gateway won't take transactions that don't have the `0x`.

is this the usual way to do it btw?