### PR TITLE
Don't log raw transaction bytes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,7 +216,7 @@ pub fn get_storage_at(pair: &(Address, H256)) -> Result<H256> {
 }
 
 pub fn execute_raw_transaction(request: &Vec<u8>) -> Result<ExecuteTransactionResponse> {
-    info!("execute_raw_transaction, request: {:?}", request);
+    info!("execute_raw_transaction");
     let decoded = match rlp::decode(request) {
         Ok(t) => t,
         Err(e) => {
@@ -275,7 +275,7 @@ fn make_unsigned_transaction(request: &TransactionRequest) -> Result<SignedTrans
 }
 
 pub fn simulate_transaction(request: &TransactionRequest) -> Result<SimulateTransactionResponse> {
-    info!("simulate_transaction, request: {:?}", request);
+    info!("simulate_transaction");
     let tx = match make_unsigned_transaction(request) {
         Ok(t) => t,
         Err(e) => {


### PR DESCRIPTION
This PR makes the `info!` invocations for `execute_raw_transaction` and `simulate_transaction` not print out the transactions. Nothing kills a development workflow like having your SSH session freeze up while printing out 700 KiB of unintelligible contract bytes.