### PR TITLE
ci: benchmark nightly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,7 +227,7 @@ jobs:
           curl -f \
             -H "Content-Type: application/json" \
             -d '{
-              "revision": "pro-wh/feature/b",
+              "revision": "master",
               "build_parameters": {
                 "CIRCLE_JOB": "benchmark-runtime-ethereum",
                 "BENCHMARK_IMAGE": "'"$benchmark_image"'",
@@ -235,7 +235,7 @@ jobs:
                 "BENCHMARK_MR_ENCLAVE": "'"$mr_enclave"'"
               }
             }' \
-            "https://circleci.com/api/v1.1/project/github/oasislabs/private-ops/tree/pro-wh/feature/b?circle-token=$CIRCLE_TOKEN"
+            "https://circleci.com/api/v1.1/project/github/oasislabs/private-ops/tree/master?circle-token=$CIRCLE_TOKEN"
 
 workflows:
   version: 2


### PR DESCRIPTION
Schedule a nightly (6 PM PDT https://www.timeanddate.com/worldclock/converter.html?iso=20180814T010000&p1=1440&p2=791&p3=736) job that:

1. builds our benchmarking docker image from master branch
2. pushes that image (always under tag `benchmarking-latest`)
3. triggers a job on private-ops to run the benchmark by image digest (https://github.com/oasislabs/private-ops/pull/133)