### PR TITLE
`hold-for-production` step needs to use `type: approval`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,6 +222,7 @@ workflows:
           requires:
             - build-and-publish-docker-image
       - hold-for-production:
+          type: approval
           requires:
             - deploy-to-staging
       - promote-to-production:


### PR DESCRIPTION
Hopefully the last mistake in this series of circleci changes.