### PR TITLE
Adds BUILD_IMAGE_TAG data to docker labels

### DIFF
--- a/docker/deployment/Dockerfile
+++ b/docker/deployment/Dockerfile
@@ -2,7 +2,9 @@ ARG BASE_DOCKER_IMAGE_TAG=latest
 FROM docker.io/oasislabs/testnet:${BASE_DOCKER_IMAGE_TAG}
 
 ARG RUNTIME_ETHEREUM_COMMIT_SHA
+ARG RUNTIME_ETHEREUM_BUILD_IMAGE_TAG
 
 LABEL com.oasislabs.runtime-ethereum-commit-sha="${RUNTIME_ETHEREUM_COMMIT_SHA}"
+LABEL com.oasislabs.runtime-ethereum-build-image-tag="${RUNTIME_ETHEREUM_BUILD_IMAGE_TAG}"
 
 ADD . /ekiden

--- a/docker/deployment/build-images.sh
+++ b/docker/deployment/build-images.sh
@@ -28,4 +28,5 @@ fi
 docker build --rm --force-rm \
     --build-arg RUNTIME_ETHEREUM_COMMIT_SHA=$runtime_ethereum_commit_sha \
     --build-arg BASE_DOCKER_IMAGE_TAG=$base_docker_image_tag \
+    --build-arg RUNTIME_ETHEREUM_BUILD_IMAGE_TAG=$BUILD_IMAGE_TAG \
     -t oasislabs/ekiden-runtime-ethereum:$BUILD_IMAGE_TAG - <target/docker-deployment/context.tar.gz


### PR DESCRIPTION
This is useful metadata for us to inspect the deployed images. It also allows us to deploy the `latest` image and still use an immutable tag as opposed to the `latest` pointer.