### PR TITLE
Fix 'promote-to-production' step.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,7 +160,7 @@ jobs:
     steps:
       # Set this as a variable so it can be changed quickly if necessary
       - run: echo 'export PRODUCTION_TAG=latest' >> $BASH_ENV
-
+      - setup_remote_docker
       - attach_workspace:
           at: /workspace
 


### PR DESCRIPTION
`setup_remote_docker` was missing, see #120