### PR TITLE
Update run-contract

### DIFF
--- a/tests/run_contract/Cargo.lock
+++ b/tests/run_contract/Cargo.lock
@@ -46,8 +46,8 @@ name = "backtrace"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace-sys 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace-sys 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "backtrace-sys"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -73,7 +73,7 @@ dependencies = [
 
 [[package]]
 name = "bigint"
-version = "4.3.0"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -83,11 +83,11 @@ dependencies = [
 
 [[package]]
 name = "bincode"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -132,7 +132,7 @@ source = "git+https://github.com/oasislabs/bn?branch=ekiden#1e80f9eed4cf5b8bf013
 dependencies = [
  "byteorder 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "crunchy 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -166,7 +166,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cfg-if"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -213,7 +213,7 @@ dependencies = [
  "keccak-hash 0.1.2 (git+https://github.com/oasislabs/parity?tag=v1.12.0-ekiden3)",
  "rlp 0.2.1 (git+https://github.com/oasislabs/parity?tag=v1.12.0-ekiden3)",
  "rlp_derive 0.1.0 (git+https://github.com/oasislabs/parity?tag=v1.12.0-ekiden3)",
- "serde 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -241,7 +241,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -255,7 +255,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -267,7 +267,7 @@ name = "crossbeam-utils"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -275,7 +275,7 @@ name = "crossbeam-utils"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -297,11 +297,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dtoa"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "edit-distance"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -314,9 +309,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "ekiden-common"
 version = "0.2.0-alpha"
-source = "git+https://github.com/oasislabs/ekiden#6bed233e15ed84255b22d482606235b6478d59c8"
+source = "git+https://github.com/oasislabs/ekiden#aafaf7fe059d443c603327138eee4168512d32ea"
 dependencies = [
- "bigint 4.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bigint 4.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -327,14 +322,14 @@ dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-sgx 0.1.18 (git+https://github.com/oasislabs/futures-rs)",
  "get_if_addrs 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_env_logger 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.12.1 (git+https://github.com/oasislabs/ring?branch=0.12.1-ekiden)",
  "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_bytes 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_cbor 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -345,7 +340,7 @@ dependencies = [
 [[package]]
 name = "ekiden-common-api"
 version = "0.2.0-alpha"
-source = "git+https://github.com/oasislabs/ekiden#6bed233e15ed84255b22d482606235b6478d59c8"
+source = "git+https://github.com/oasislabs/ekiden#aafaf7fe059d443c603327138eee4168512d32ea"
 dependencies = [
  "ekiden-grpcio 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ekiden-tools 0.2.0-alpha (git+https://github.com/oasislabs/ekiden)",
@@ -357,10 +352,10 @@ dependencies = [
 [[package]]
 name = "ekiden-contract-common"
 version = "0.2.0-alpha"
-source = "git+https://github.com/oasislabs/ekiden#6bed233e15ed84255b22d482606235b6478d59c8"
+source = "git+https://github.com/oasislabs/ekiden#aafaf7fe059d443c603327138eee4168512d32ea"
 dependencies = [
  "ekiden-common 0.2.0-alpha (git+https://github.com/oasislabs/ekiden)",
- "serde 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_cbor 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -368,7 +363,7 @@ dependencies = [
 [[package]]
 name = "ekiden-contract-edl"
 version = "0.2.0-alpha"
-source = "git+https://github.com/oasislabs/ekiden#6bed233e15ed84255b22d482606235b6478d59c8"
+source = "git+https://github.com/oasislabs/ekiden#aafaf7fe059d443c603327138eee4168512d32ea"
 dependencies = [
  "ekiden-tools 0.2.0-alpha (git+https://github.com/oasislabs/ekiden)",
 ]
@@ -376,20 +371,20 @@ dependencies = [
 [[package]]
 name = "ekiden-contract-trusted"
 version = "0.2.0-alpha"
-source = "git+https://github.com/oasislabs/ekiden#6bed233e15ed84255b22d482606235b6478d59c8"
+source = "git+https://github.com/oasislabs/ekiden#aafaf7fe059d443c603327138eee4168512d32ea"
 dependencies = [
  "ekiden-common 0.2.0-alpha (git+https://github.com/oasislabs/ekiden)",
  "ekiden-contract-common 0.2.0-alpha (git+https://github.com/oasislabs/ekiden)",
  "ekiden-enclave-trusted 0.2.0-alpha (git+https://github.com/oasislabs/ekiden)",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_cbor 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ekiden-core"
 version = "0.2.0-alpha"
-source = "git+https://github.com/oasislabs/ekiden#6bed233e15ed84255b22d482606235b6478d59c8"
+source = "git+https://github.com/oasislabs/ekiden#aafaf7fe059d443c603327138eee4168512d32ea"
 dependencies = [
  "ekiden-common 0.2.0-alpha (git+https://github.com/oasislabs/ekiden)",
  "ekiden-contract-common 0.2.0-alpha (git+https://github.com/oasislabs/ekiden)",
@@ -400,7 +395,7 @@ dependencies = [
 [[package]]
 name = "ekiden-db-edl"
 version = "0.2.0-alpha"
-source = "git+https://github.com/oasislabs/ekiden#6bed233e15ed84255b22d482606235b6478d59c8"
+source = "git+https://github.com/oasislabs/ekiden#aafaf7fe059d443c603327138eee4168512d32ea"
 dependencies = [
  "ekiden-tools 0.2.0-alpha (git+https://github.com/oasislabs/ekiden)",
 ]
@@ -408,9 +403,9 @@ dependencies = [
 [[package]]
 name = "ekiden-db-trusted"
 version = "0.2.0-alpha"
-source = "git+https://github.com/oasislabs/ekiden#6bed233e15ed84255b22d482606235b6478d59c8"
+source = "git+https://github.com/oasislabs/ekiden#aafaf7fe059d443c603327138eee4168512d32ea"
 dependencies = [
- "bincode 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bincode 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ekiden-common 0.2.0-alpha (git+https://github.com/oasislabs/ekiden)",
  "ekiden-enclave-trusted 0.2.0-alpha (git+https://github.com/oasislabs/ekiden)",
  "ekiden-storage-base 0.2.0-alpha (git+https://github.com/oasislabs/ekiden)",
@@ -419,7 +414,7 @@ dependencies = [
  "ekiden-tools 0.2.0-alpha (git+https://github.com/oasislabs/ekiden)",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "sodalite 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -427,7 +422,7 @@ dependencies = [
 [[package]]
 name = "ekiden-di"
 version = "0.2.0-alpha"
-source = "git+https://github.com/oasislabs/ekiden#6bed233e15ed84255b22d482606235b6478d59c8"
+source = "git+https://github.com/oasislabs/ekiden#aafaf7fe059d443c603327138eee4168512d32ea"
 dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -436,20 +431,20 @@ dependencies = [
 [[package]]
 name = "ekiden-edl"
 version = "0.2.0-alpha"
-source = "git+https://github.com/oasislabs/ekiden#6bed233e15ed84255b22d482606235b6478d59c8"
+source = "git+https://github.com/oasislabs/ekiden#aafaf7fe059d443c603327138eee4168512d32ea"
 dependencies = [
  "ekiden-contract-edl 0.2.0-alpha (git+https://github.com/oasislabs/ekiden)",
  "ekiden-db-edl 0.2.0-alpha (git+https://github.com/oasislabs/ekiden)",
  "ekiden-enclave-edl 0.2.0-alpha (git+https://github.com/oasislabs/ekiden)",
  "ekiden-rpc-edl 0.2.0-alpha (git+https://github.com/oasislabs/ekiden)",
  "ekiden-tools 0.2.0-alpha (git+https://github.com/oasislabs/ekiden)",
- "sgx_edl 0.9.7 (git+https://github.com/oasislabs/rust-sgx-sdk?tag=v0.9.8-ekiden1)",
+ "sgx_edl 0.9.7 (git+https://github.com/oasislabs/rust-sgx-sdk?tag=v1.0.1-ekiden1)",
 ]
 
 [[package]]
 name = "ekiden-enclave-common"
 version = "0.2.0-alpha"
-source = "git+https://github.com/oasislabs/ekiden#6bed233e15ed84255b22d482606235b6478d59c8"
+source = "git+https://github.com/oasislabs/ekiden#aafaf7fe059d443c603327138eee4168512d32ea"
 dependencies = [
  "base64 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -459,10 +454,10 @@ dependencies = [
  "pem-iterator 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "sgx_types 0.9.8 (git+https://github.com/oasislabs/rust-sgx-sdk?tag=v0.9.8-ekiden1)",
+ "rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sgx_types 1.0.1 (git+https://github.com/oasislabs/rust-sgx-sdk?tag=v1.0.1-ekiden1)",
  "sodalite 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "webpki 0.17.0 (git+https://github.com/oasislabs/webpki?branch=0.17.0-ekiden)",
 ]
@@ -470,7 +465,7 @@ dependencies = [
 [[package]]
 name = "ekiden-enclave-edl"
 version = "0.2.0-alpha"
-source = "git+https://github.com/oasislabs/ekiden#6bed233e15ed84255b22d482606235b6478d59c8"
+source = "git+https://github.com/oasislabs/ekiden#aafaf7fe059d443c603327138eee4168512d32ea"
 dependencies = [
  "ekiden-tools 0.2.0-alpha (git+https://github.com/oasislabs/ekiden)",
 ]
@@ -478,23 +473,23 @@ dependencies = [
 [[package]]
 name = "ekiden-enclave-logger"
 version = "0.2.0-alpha"
-source = "git+https://github.com/oasislabs/ekiden#6bed233e15ed84255b22d482606235b6478d59c8"
+source = "git+https://github.com/oasislabs/ekiden#aafaf7fe059d443c603327138eee4168512d32ea"
 dependencies = [
- "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ekiden-enclave-trusted"
 version = "0.2.0-alpha"
-source = "git+https://github.com/oasislabs/ekiden#6bed233e15ed84255b22d482606235b6478d59c8"
+source = "git+https://github.com/oasislabs/ekiden#aafaf7fe059d443c603327138eee4168512d32ea"
 dependencies = [
  "ekiden-common 0.2.0-alpha (git+https://github.com/oasislabs/ekiden)",
  "ekiden-enclave-common 0.2.0-alpha (git+https://github.com/oasislabs/ekiden)",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_cbor 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sgx_types 0.9.8 (git+https://github.com/oasislabs/rust-sgx-sdk?tag=v0.9.8-ekiden1)",
+ "sgx_types 1.0.1 (git+https://github.com/oasislabs/rust-sgx-sdk?tag=v1.0.1-ekiden1)",
  "sodalite 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -516,7 +511,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "cmake 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cmake 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -525,19 +520,19 @@ dependencies = [
 [[package]]
 name = "ekiden-keymanager-api"
 version = "0.2.0-alpha"
-source = "git+https://github.com/oasislabs/ekiden#6bed233e15ed84255b22d482606235b6478d59c8"
+source = "git+https://github.com/oasislabs/ekiden#aafaf7fe059d443c603327138eee4168512d32ea"
 dependencies = [
  "ekiden-core 0.2.0-alpha (git+https://github.com/oasislabs/ekiden)",
  "ekiden-tools 0.2.0-alpha (git+https://github.com/oasislabs/ekiden)",
  "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "protoc-grpcio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ekiden-keymanager-client"
 version = "0.2.0-alpha"
-source = "git+https://github.com/oasislabs/ekiden#6bed233e15ed84255b22d482606235b6478d59c8"
+source = "git+https://github.com/oasislabs/ekiden#aafaf7fe059d443c603327138eee4168512d32ea"
 dependencies = [
  "ekiden-common 0.2.0-alpha (git+https://github.com/oasislabs/ekiden)",
  "ekiden-enclave-common 0.2.0-alpha (git+https://github.com/oasislabs/ekiden)",
@@ -548,17 +543,17 @@ dependencies = [
  "ekiden-rpc-common 0.2.0-alpha (git+https://github.com/oasislabs/ekiden)",
  "ekiden-rpc-trusted 0.2.0-alpha (git+https://github.com/oasislabs/ekiden)",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_cbor 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ekiden-keymanager-common"
 version = "0.2.0-alpha"
-source = "git+https://github.com/oasislabs/ekiden#6bed233e15ed84255b22d482606235b6478d59c8"
+source = "git+https://github.com/oasislabs/ekiden#aafaf7fe059d443c603327138eee4168512d32ea"
 dependencies = [
  "ekiden-common 0.2.0-alpha (git+https://github.com/oasislabs/ekiden)",
- "serde 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "sodalite 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -566,7 +561,7 @@ dependencies = [
 [[package]]
 name = "ekiden-rpc-api"
 version = "0.2.0-alpha"
-source = "git+https://github.com/oasislabs/ekiden#6bed233e15ed84255b22d482606235b6478d59c8"
+source = "git+https://github.com/oasislabs/ekiden#aafaf7fe059d443c603327138eee4168512d32ea"
 dependencies = [
  "ekiden-grpcio 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ekiden-tools 0.2.0-alpha (git+https://github.com/oasislabs/ekiden)",
@@ -578,7 +573,7 @@ dependencies = [
 [[package]]
 name = "ekiden-rpc-client"
 version = "0.2.0-alpha"
-source = "git+https://github.com/oasislabs/ekiden#6bed233e15ed84255b22d482606235b6478d59c8"
+source = "git+https://github.com/oasislabs/ekiden#aafaf7fe059d443c603327138eee4168512d32ea"
 dependencies = [
  "byteorder 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ekiden-common 0.2.0-alpha (git+https://github.com/oasislabs/ekiden)",
@@ -589,8 +584,8 @@ dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-sgx 0.1.18 (git+https://github.com/oasislabs/futures-rs)",
  "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_cbor 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sodalite 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -598,22 +593,22 @@ dependencies = [
 [[package]]
 name = "ekiden-rpc-common"
 version = "0.2.0-alpha"
-source = "git+https://github.com/oasislabs/ekiden#6bed233e15ed84255b22d482606235b6478d59c8"
+source = "git+https://github.com/oasislabs/ekiden#aafaf7fe059d443c603327138eee4168512d32ea"
 dependencies = [
  "byteorder 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ekiden-common 0.2.0-alpha (git+https://github.com/oasislabs/ekiden)",
  "ekiden-enclave-common 0.2.0-alpha (git+https://github.com/oasislabs/ekiden)",
  "ekiden-tools 0.2.0-alpha (git+https://github.com/oasislabs/ekiden)",
  "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "sodalite 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ekiden-rpc-edl"
 version = "0.2.0-alpha"
-source = "git+https://github.com/oasislabs/ekiden#6bed233e15ed84255b22d482606235b6478d59c8"
+source = "git+https://github.com/oasislabs/ekiden#aafaf7fe059d443c603327138eee4168512d32ea"
 dependencies = [
  "ekiden-tools 0.2.0-alpha (git+https://github.com/oasislabs/ekiden)",
 ]
@@ -621,7 +616,7 @@ dependencies = [
 [[package]]
 name = "ekiden-rpc-trusted"
 version = "0.2.0-alpha"
-source = "git+https://github.com/oasislabs/ekiden#6bed233e15ed84255b22d482606235b6478d59c8"
+source = "git+https://github.com/oasislabs/ekiden#aafaf7fe059d443c603327138eee4168512d32ea"
 dependencies = [
  "ekiden-common 0.2.0-alpha (git+https://github.com/oasislabs/ekiden)",
  "ekiden-enclave-common 0.2.0-alpha (git+https://github.com/oasislabs/ekiden)",
@@ -633,8 +628,8 @@ dependencies = [
  "futures-sgx 0.1.18 (git+https://github.com/oasislabs/futures-rs)",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_cbor 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sodalite 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -642,7 +637,7 @@ dependencies = [
 [[package]]
 name = "ekiden-storage-api"
 version = "0.2.0-alpha"
-source = "git+https://github.com/oasislabs/ekiden#6bed233e15ed84255b22d482606235b6478d59c8"
+source = "git+https://github.com/oasislabs/ekiden#aafaf7fe059d443c603327138eee4168512d32ea"
 dependencies = [
  "ekiden-grpcio 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ekiden-tools 0.2.0-alpha (git+https://github.com/oasislabs/ekiden)",
@@ -654,19 +649,19 @@ dependencies = [
 [[package]]
 name = "ekiden-storage-base"
 version = "0.2.0-alpha"
-source = "git+https://github.com/oasislabs/ekiden#6bed233e15ed84255b22d482606235b6478d59c8"
+source = "git+https://github.com/oasislabs/ekiden#aafaf7fe059d443c603327138eee4168512d32ea"
 dependencies = [
  "ekiden-common 0.2.0-alpha (git+https://github.com/oasislabs/ekiden)",
  "ekiden-grpcio 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ekiden-storage-api 0.2.0-alpha (git+https://github.com/oasislabs/ekiden)",
- "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ekiden-storage-dummy"
 version = "0.2.0-alpha"
-source = "git+https://github.com/oasislabs/ekiden#6bed233e15ed84255b22d482606235b6478d59c8"
+source = "git+https://github.com/oasislabs/ekiden#aafaf7fe059d443c603327138eee4168512d32ea"
 dependencies = [
  "ekiden-common 0.2.0-alpha (git+https://github.com/oasislabs/ekiden)",
  "ekiden-di 0.2.0-alpha (git+https://github.com/oasislabs/ekiden)",
@@ -676,7 +671,7 @@ dependencies = [
 [[package]]
 name = "ekiden-storage-lru"
 version = "0.2.0-alpha"
-source = "git+https://github.com/oasislabs/ekiden#6bed233e15ed84255b22d482606235b6478d59c8"
+source = "git+https://github.com/oasislabs/ekiden#aafaf7fe059d443c603327138eee4168512d32ea"
 dependencies = [
  "ekiden-common 0.2.0-alpha (git+https://github.com/oasislabs/ekiden)",
  "ekiden-storage-base 0.2.0-alpha (git+https://github.com/oasislabs/ekiden)",
@@ -686,7 +681,7 @@ dependencies = [
 [[package]]
 name = "ekiden-tools"
 version = "0.2.0-alpha"
-source = "git+https://github.com/oasislabs/ekiden#6bed233e15ed84255b22d482606235b6478d59c8"
+source = "git+https://github.com/oasislabs/ekiden#aafaf7fe059d443c603327138eee4168512d32ea"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -699,16 +694,16 @@ dependencies = [
  "protoc-rust 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
- "sgx_edl 0.9.7 (git+https://github.com/oasislabs/rust-sgx-sdk?tag=v0.9.8-ekiden1)",
+ "sgx_edl 0.9.7 (git+https://github.com/oasislabs/rust-sgx-sdk?tag=v1.0.1-ekiden1)",
  "toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ekiden-trusted"
 version = "0.2.0-alpha"
-source = "git+https://github.com/oasislabs/ekiden#6bed233e15ed84255b22d482606235b6478d59c8"
+source = "git+https://github.com/oasislabs/ekiden#aafaf7fe059d443c603327138eee4168512d32ea"
 dependencies = [
  "ekiden-contract-trusted 0.2.0-alpha (git+https://github.com/oasislabs/ekiden)",
  "ekiden-db-trusted 0.2.0-alpha (git+https://github.com/oasislabs/ekiden)",
@@ -732,7 +727,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -763,9 +758,9 @@ dependencies = [
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethereum-types 0.3.2 (git+https://github.com/oasislabs/primitives?branch=ekiden)",
  "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -788,12 +783,12 @@ dependencies = [
 [[package]]
 name = "ethbloom"
 version = "0.5.0"
-source = "git+https://github.com/oasislabs/primitives?branch=ekiden#3c34adbb27fdf3fd446669bc6731f2433d99a904"
+source = "git+https://github.com/oasislabs/primitives?branch=ekiden#29be980b7409ad3ea25bc95298ba01595d020891"
 dependencies = [
  "crunchy 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethereum-types-serialize 0.2.1 (git+https://github.com/oasislabs/primitives?branch=ekiden)",
  "fixed-hash 0.2.1 (git+https://github.com/oasislabs/primitives?branch=ekiden)",
- "serde 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -881,30 +876,30 @@ dependencies = [
  "ekiden-tools 0.2.0-alpha (git+https://github.com/oasislabs/ekiden)",
  "ethereum-types 0.3.2 (git+https://github.com/oasislabs/primitives?branch=ekiden)",
  "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ethereum-types"
 version = "0.3.2"
-source = "git+https://github.com/oasislabs/primitives?branch=ekiden#3c34adbb27fdf3fd446669bc6731f2433d99a904"
+source = "git+https://github.com/oasislabs/primitives?branch=ekiden#29be980b7409ad3ea25bc95298ba01595d020891"
 dependencies = [
  "crunchy 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethbloom 0.5.0 (git+https://github.com/oasislabs/primitives?branch=ekiden)",
  "ethereum-types-serialize 0.2.1 (git+https://github.com/oasislabs/primitives?branch=ekiden)",
  "fixed-hash 0.2.1 (git+https://github.com/oasislabs/primitives?branch=ekiden)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "uint 0.2.1 (git+https://github.com/oasislabs/primitives?branch=ekiden)",
 ]
 
 [[package]]
 name = "ethereum-types-serialize"
 version = "0.2.1"
-source = "git+https://github.com/oasislabs/primitives?branch=ekiden#3c34adbb27fdf3fd446669bc6731f2433d99a904"
+source = "git+https://github.com/oasislabs/primitives?branch=ekiden#29be980b7409ad3ea25bc95298ba01595d020891"
 dependencies = [
- "serde 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -914,9 +909,9 @@ source = "git+https://github.com/oasislabs/parity?tag=v1.12.0-ekiden3#9c0b6fca53
 dependencies = [
  "ethereum-types 0.3.2 (git+https://github.com/oasislabs/primitives?branch=ekiden)",
  "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -965,7 +960,7 @@ name = "failure_derive"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.14.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -984,10 +979,9 @@ dependencies = [
 [[package]]
 name = "fixed-hash"
 version = "0.2.1"
-source = "git+https://github.com/oasislabs/primitives?branch=ekiden#3c34adbb27fdf3fd446669bc6731f2433d99a904"
+source = "git+https://github.com/oasislabs/primitives?branch=ekiden#29be980b7409ad3ea25bc95298ba01595d020891"
 dependencies = [
  "heapsize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1191,7 +1185,7 @@ name = "lazy_static"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "spin 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spin 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1215,15 +1209,15 @@ name = "log"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1296,7 +1290,7 @@ dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1332,7 +1326,7 @@ name = "net2"
 version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1391,7 +1385,7 @@ version = "0.10.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1406,7 +1400,7 @@ dependencies = [
  "cc 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "vcpkg 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vcpkg 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1472,7 +1466,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1485,7 +1479,7 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1509,7 +1503,7 @@ name = "protoc"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1542,7 +1536,7 @@ version = "0.2.1"
 source = "git+https://github.com/oasislabs/wasm-utils?branch=ekiden#68d9b631817476bdc1c97dd569a8e5d6a8795e80"
 dependencies = [
  "byteorder 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-wasm 0.30.0 (git+https://github.com/oasislabs/parity-wasm?branch=ekiden)",
 ]
 
@@ -1564,7 +1558,7 @@ name = "quote"
 version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1574,12 +1568,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rand"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1627,7 +1621,7 @@ dependencies = [
  "aho-corasick 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1729,7 +1723,7 @@ dependencies = [
  "ethereum-types 0.3.2 (git+https://github.com/oasislabs/primitives?branch=ekiden)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha3 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1756,6 +1750,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "ryu"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "safemem"
@@ -1794,7 +1793,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.59"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1802,7 +1801,7 @@ name = "serde_bytes"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1811,7 +1810,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1819,30 +1818,30 @@ name = "serde_derive"
 version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.14.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.17"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ryu 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sgx_edl"
 version = "0.9.7"
-source = "git+https://github.com/oasislabs/rust-sgx-sdk?tag=v0.9.8-ekiden1#d65ed33d1ea460144800bda1d151629a6bff69fa"
+source = "git+https://github.com/oasislabs/rust-sgx-sdk?tag=v1.0.1-ekiden1#85b88d1aa20dc2ddfe2cbf3b400fd748b47b1e87"
 
 [[package]]
 name = "sgx_types"
-version = "0.9.8"
-source = "git+https://github.com/oasislabs/rust-sgx-sdk?tag=v0.9.8-ekiden1#d65ed33d1ea460144800bda1d151629a6bff69fa"
+version = "1.0.1"
+source = "git+https://github.com/oasislabs/rust-sgx-sdk?tag=v1.0.1-ekiden1#85b88d1aa20dc2ddfe2cbf3b400fd748b47b1e87"
 
 [[package]]
 name = "sha3"
@@ -1875,7 +1874,7 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1898,7 +1897,7 @@ name = "syn"
 version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1908,7 +1907,7 @@ name = "synstructure"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.14.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1919,7 +1918,7 @@ name = "tempdir"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1951,11 +1950,10 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2028,7 +2026,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2037,7 +2035,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2064,9 +2062,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-deque 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2086,7 +2084,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2098,7 +2096,7 @@ name = "toml"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2125,7 +2123,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "uint"
 version = "0.2.1"
-source = "git+https://github.com/oasislabs/primitives?branch=ekiden#3c34adbb27fdf3fd446669bc6731f2433d99a904"
+source = "git+https://github.com/oasislabs/primitives?branch=ekiden#29be980b7409ad3ea25bc95298ba01595d020891"
 dependencies = [
  "byteorder 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2152,14 +2150,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "unicode-xid"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "unreachable"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "untrusted"
@@ -2194,7 +2184,7 @@ dependencies = [
 
 [[package]]
 name = "vcpkg"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2222,11 +2212,6 @@ dependencies = [
  "patricia-trie 0.1.0 (git+https://github.com/oasislabs/parity?tag=v1.12.0-ekiden3)",
  "rlp 0.2.1 (git+https://github.com/oasislabs/parity?tag=v1.12.0-ekiden3)",
 ]
-
-[[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "wasm"
@@ -2315,10 +2300,10 @@ dependencies = [
 "checksum arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a1e964f9e24d588183fcb43503abda40d288c8657dfc27311516ce2f05675aef"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
 "checksum backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "89a47830402e9981c5c41223151efcced65a0510c13097c769cede7efb34782a"
-"checksum backtrace-sys 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)" = "bff67d0c06556c0b8e6b5f090f0eac52d950d9dfd1d35ba04e4ca3543eaf6a7e"
+"checksum backtrace-sys 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)" = "c66d56ac8dabd07f6aacdaf633f4b8262f5b3601a810a0dcddffd5c22c69daa0"
 "checksum base64 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "85415d2594767338a74a30c1d370b2f3262ec1b4ed2d7bba5b3faf4de40467d9"
-"checksum bigint 4.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4a6d961f23ce43ce7391b994c78174691e41274a5c48a1cda69caf04af173e1"
-"checksum bincode 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bda13183df33055cbb84b847becce220d392df502ebe7a4a78d7021771ed94d0"
+"checksum bigint 4.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "da1dde4308822ffaa13665757273a1b787481212f3f9b1c470a864b179a01f1b"
+"checksum bincode 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9f2fb9e29e72fd6bc12071533d5dc7664cb01480c59406f656d7ac25c7bd8ff7"
 "checksum bit-set 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9bf6104718e80d7b26a68fdbacff3481cfc05df670821affc7e9cbc1884400c"
 "checksum bit-vec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "02b4ff8b16e6076c3e14220b39fbc1fabb6737522281a388998046859400895f"
 "checksum bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d0c54bb8f454c567f21197eefcdbf5679d0bd99f2ddbe52e84c77061952e6789"
@@ -2330,10 +2315,10 @@ dependencies = [
 "checksum bytes 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e178b8e0e239e844b083d5a0d4a156b2654e67f9f80144d48398fcd736a24fb8"
 "checksum c_linked_list 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4964518bd3b4a8190e832886cdc0da9794f12e8e6c1613a9e90ff331c4c8724b"
 "checksum cc 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)" = "2119ea4867bd2b8ed3aecab467709720b2d55b1bcfe09f772fd68066eaf15275"
-"checksum cfg-if 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "efe5c877e17a9c717a0bf3613b2709f723202c4e4675cc8f12926ded29bcb17e"
+"checksum cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0c4e7bb64a8ebb0d856483e1e682ea3422f883c5f5615a90d51a2c82fe87fdd3"
 "checksum chrono 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e48d85528df61dc964aa43c5f6ca681a19cfa74939b2348d204bd08a981f2fb0"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
-"checksum cmake 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "b56821938fa1a3aaf4f0c4f49504928c5a7fcc56cbc9855be8fc2e98567e750c"
+"checksum cmake 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)" = "704fbf3bb5149daab0afb255dbea24a1f08d2f4099cedb9baab6d470d4c5eefb"
 "checksum common-types 0.1.0 (git+https://github.com/oasislabs/parity?tag=v1.12.0-ekiden3)" = "<none>"
 "checksum crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f739f8c5363aca78cfb059edf753d8f0d36908c348f3d8d1503f03d8b75d9cf3"
 "checksum crossbeam-deque 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fe8153ef04a7594ded05b427ffad46ddeaf22e63fd48d42b3e1e3bb4db07cae7"
@@ -2344,7 +2329,6 @@ dependencies = [
 "checksum crunchy 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a2f4a431c5c9f662e1200b7c7f02c34e91361150e382089a8f2dec3ba680cbda"
 "checksum crunchy 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c240f247c278fa08a6d4820a6a222bfc6e0d999e51ba67be94f44c905b2161f2"
 "checksum digest 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e5b29bf156f3f4b3c4f610a25ff69370616ae6e0657d416de22645483e72af0a"
-"checksum dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6d301140eb411af13d3115f9a562c85cc6b541ade9dfa314132244aaee7489dd"
 "checksum edit-distance 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3bd26878c3d921f89797a4e1a1711919f999a9f6946bb6f5a4ffda126d297b7e"
 "checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
 "checksum ekiden-common 0.2.0-alpha (git+https://github.com/oasislabs/ekiden)" = "<none>"
@@ -2429,7 +2413,7 @@ dependencies = [
 "checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
 "checksum linked-hash-map 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7860ec297f7008ff7a1e3382d7f7e1dcd69efc94751a2284bafc3d013c2aa939"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
-"checksum log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "61bd98ae7f7b754bc53dca7d44b604f733c6bba044ea6f41bc8d89272d8161d2"
+"checksum log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cba860f648db8e6f269df990180c2217f333472b4a6e901e97446858487971e2"
 "checksum lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4d06ff7ff06f729ce5f4e227876cb88d10bc59cd4ae1e09fbb2bde15c850dc21"
 "checksum macros 0.1.0 (git+https://github.com/oasislabs/parity?tag=v1.12.0-ekiden3)" = "<none>"
 "checksum mem 0.1.0 (git+https://github.com/oasislabs/parity?tag=v1.12.0-ekiden3)" = "<none>"
@@ -2461,7 +2445,7 @@ dependencies = [
 "checksum plain_hasher 0.1.0 (git+https://github.com/oasislabs/parity?tag=v1.12.0-ekiden3)" = "<none>"
 "checksum pretty_env_logger 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8ae1b463255bf6613ad435f8997cb57f5d045ef35eb255f5a3d6085be936bd79"
 "checksum proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1b06e2f335f48d24442b35a19df506a835fb3547bc3c06ef27340da9acf5cae7"
-"checksum proc-macro2 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "762eea716b821300a86da08870a64b597304866ceb9f54a11d67b4cf56459c6a"
+"checksum proc-macro2 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)" = "ee5697238f0d893c7f0ecc59c0999f18d2af85e424de441178bcacc9f9e6cf67"
 "checksum protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "128a4f37a2df739a567a8685b17f54aa19b9c3c4a6a5b8731e97a419b3db451c"
 "checksum protobuf-codegen 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3624c0feac7f512de21dbf8b574ae65c6573b1872d3878be951c0912eee4daca"
 "checksum protoc 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8736a41d7c7e321913dd81067fbedf74d037f69999386eba07cc4dd1de7369f0"
@@ -2472,7 +2456,7 @@ dependencies = [
 "checksum quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9949cfe66888ffe1d53e6ec9d9f3b70714083854be20fd5e271b232a017401e8"
 "checksum quote 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ed7d650913520df631972f21e104a4fa2f9c82a14afc65d17b388a2e29731e7c"
 "checksum rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "15a732abf9d20f0ad8eeb6f909bf6868722d9a06e1e50802b6a70351f40b4eb1"
-"checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
+"checksum rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8356f47b32624fef5b3301c1be97e5944ecdd595409cc5da11d05f211db6cfbd"
 "checksum rayon 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b614fe08b6665cb9a231d07ac1364b0ef3cb3698f1239ee0c4c3a88a524f54c8"
 "checksum rayon-core 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b055d1e92aba6877574d8fe604a63c8b5df60f60e5982bf7ccbb1338ea527356"
 "checksum redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "c214e91d3ecf43e9a4e41e578973adeb14b474f2bee858742d127af75a0112b1"
@@ -2489,23 +2473,24 @@ dependencies = [
 "checksum rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0ceb8ce7a5e520de349e1fa172baeba4a9e8d5ef06c47471863530bc4972ee1e"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+"checksum ryu 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "16aa12da69951804cddf5f74d96abcc414a31b064e610dc81e37c1536082f491"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum secp256k1-plus 0.5.7 (git+https://github.com/oasislabs/rust-secp256k1?branch=feature/rand_optional)" = "<none>"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-"checksum serde 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)" = "2a4d976362a13caad61c38cf841401d2d4d480496a9391c3842c288b01f9de95"
+"checksum serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)" = "6dfad05c8854584e5f72fb859385ecdfa03af69c3fd0572f0da2d4c95f060bdb"
 "checksum serde_bytes 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)" = "adb6e51a6b3696b301bc221d785f898b4457c619b51d7ce195a6d20baecb37b3"
 "checksum serde_cbor 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b4ad7872ff6e6c2a9221f4c1abe681e7eefc56ca5b3e87196afbfc717d141dc8"
 "checksum serde_derive 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)" = "b719c6d5e9f73fbc37892246d5852333f040caa617b8873c6aced84bcb28e7bb"
-"checksum serde_json 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)" = "f3ad6d546e765177cf3dded3c2e424a8040f870083a0e64064746b958ece9cb1"
-"checksum sgx_edl 0.9.7 (git+https://github.com/oasislabs/rust-sgx-sdk?tag=v0.9.8-ekiden1)" = "<none>"
-"checksum sgx_types 0.9.8 (git+https://github.com/oasislabs/rust-sgx-sdk?tag=v0.9.8-ekiden1)" = "<none>"
+"checksum serde_json 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)" = "44dd2cfde475037451fa99b7e5df77aa3cfd1536575fa8e7a538ab36dcde49ae"
+"checksum sgx_edl 0.9.7 (git+https://github.com/oasislabs/rust-sgx-sdk?tag=v1.0.1-ekiden1)" = "<none>"
+"checksum sgx_types 1.0.1 (git+https://github.com/oasislabs/rust-sgx-sdk?tag=v1.0.1-ekiden1)" = "<none>"
 "checksum sha3 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "26405905b6a56a94c60109cfda62610507ac14a65be531f5767dec5c5a8dd6a0"
 "checksum siphasher 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "833011ca526bd88f16778d32c699d325a9ad302fa06381cd66f7be63351d3f6d"
 "checksum slab 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5f9776d6b986f77b35c6cf846c11ad986ff128fe0b2b63a3628e3755e8d3102d"
 "checksum sodalite 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "67643084c740297bac275b1d97901ec27ca5984be4e8f75d86a33498e0e3e61c"
-"checksum spin 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14db77c5b914df6d6173dda9a3b3f5937bd802934fa5edaf934df06a3491e56f"
+"checksum spin 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "37b5646825922b96b5d7d676b5bb3458a54498e96ed7b0ce09dc43a07038fea4"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum syn 0.13.11 (registry+https://github.com/rust-lang/crates.io-index)" = "14f9bf6292f3a61d2c716723fdb789a41bbe104168e6f496dc6497e531ea1b9b"
 "checksum syn 0.14.8 (registry+https://github.com/rust-lang/crates.io-index)" = "b7bfcbb0c068d0f642a0ffbd5c604965a360a61f99e8add013cef23a838614f3"
@@ -2514,7 +2499,7 @@ dependencies = [
 "checksum termcolor 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "722426c4a0539da2c4ffd9b419d90ad540b4cff4a053be9069c908d4d07e2836"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6"
-"checksum thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"
+"checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "d825be0eb33fda1a7e68012d51e9c7f451dc1a69391e7fdc197060bb8c56667b"
 "checksum tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e9175261fbdb60781fcd388a4d6cc7e14764a2b629a7ad94abb439aed223a44f"
 "checksum tokio 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8ee337e5f4e501fc32966fec6fe0ca0cc1c237b0b1b14a335f8bfe3c5f06e286"
@@ -2536,16 +2521,14 @@ dependencies = [
 "checksum unicode-segmentation 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "aa6024fc12ddfd1c6dbc14a80fa2324d4568849869b779f6bd37e5e4c03344d1"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
-"checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 "checksum untrusted 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f392d7819dbe58833e26872f5f6f0d68b7bbbe90fc3667e98731c4a15ad9a7ae"
 "checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
 "checksum util-error 0.1.0 (git+https://github.com/oasislabs/parity?tag=v1.12.0-ekiden3)" = "<none>"
 "checksum uuid 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "78c590b5bd79ed10aad8fb75f078a59d8db445af6c743e55c4a53227fc01c13f"
-"checksum vcpkg 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cbe533e138811704c0e3cbde65a818b35d3240409b4346256c5ede403e082474"
+"checksum vcpkg 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a51475940ea5ed2f7ba8e7b867c42d6cb7f06fafb9c1673ed8e768c675c771cc"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7716c242968ee87e5542f8021178248f267f295a5c4803beae8b8b7fd9bc6051"
 "checksum vm 0.1.0 (git+https://github.com/oasislabs/parity?tag=v1.12.0-ekiden3)" = "<none>"
-"checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum wasm 0.1.0 (git+https://github.com/oasislabs/parity?tag=v1.12.0-ekiden3)" = "<none>"
 "checksum wasmi 0.2.0 (git+https://github.com/oasislabs/wasmi?branch=ekiden)" = "<none>"
 "checksum webpki 0.17.0 (git+https://github.com/oasislabs/webpki?branch=0.17.0-ekiden)" = "<none>"

--- a/tests/run_contract/src/bin/main.rs
+++ b/tests/run_contract/src/bin/main.rs
@@ -1,0 +1,42 @@
+#[macro_use]
+extern crate clap;
+extern crate either;
+extern crate ethcore;
+extern crate run_contract;
+
+use std::fs;
+
+use clap::Arg;
+use either::Either;
+use ethcore::rlp;
+
+use run_contract::{make_tx, run_tx};
+
+fn main() {
+    let args = app_from_crate!()
+        .arg(
+            Arg::with_name("contract")
+                .help("path to file containing contract bytecode")
+                .required(true)
+                .index(1),
+        )
+        .arg(
+            Arg::with_name("dump-tx")
+                .long("dump-tx")
+                .value_name("FILE")
+                .help("dump RLP-encoded transaction to file")
+                .takes_value(true),
+        )
+        .get_matches();
+
+    let contract = fs::read(args.value_of("contract").unwrap()).unwrap();
+    let create_tx = make_tx(Either::Left(contract));
+    if let Some(tx_file) = args.value_of("dump-tx") {
+        fs::write(tx_file, rlp::encode(&create_tx)).unwrap();
+    }
+    let contract_address = run_tx(create_tx).unwrap().contract_address.unwrap();
+    println!(
+        "{:?}",
+        run_tx(make_tx(Either::Right((contract_address, Vec::new())))).unwrap()
+    )
+}

--- a/tests/run_contract/src/lib.rs
+++ b/tests/run_contract/src/lib.rs
@@ -1,5 +1,3 @@
-#[macro_use]
-extern crate clap;
 extern crate either;
 extern crate ethcore;
 extern crate ethereum_api;
@@ -9,15 +7,15 @@ extern crate ethkey;
 extern crate lazy_static;
 extern crate runtime_ethereum;
 
-use clap::Arg;
+use std::str::FromStr;
+
 use either::Either;
 use ethcore::{rlp,
               transaction::{Action, SignedTransaction, Transaction}};
-use ethereum_api::Receipt;
+use ethereum_api::{ExecuteTransactionResponse, Receipt};
 use ethereum_types::{Address, U256};
 use ethkey::Secret;
 use runtime_ethereum::{execute_raw_transaction, get_account_nonce, get_receipt};
-use std::{fs, str::FromStr};
 
 lazy_static! {
     static ref DEFAULT_ACCOUNT: Address = Address::from("1cca28600d7491365520b31b466f88647b9839ec");
@@ -28,51 +26,30 @@ lazy_static! {
     ).unwrap();
 }
 
-fn make_tx(spec: Either<Vec<u8>, Address>) -> SignedTransaction {
+/// Makes a transaction.
+/// Either a CREATE containing the contract bytes or a CALL to an address with some data bytes.
+pub fn make_tx(spec: Either<Vec<u8>, (Address, Vec<u8>)>) -> SignedTransaction {
     let mut tx = Transaction::default();
     tx.gas = U256::from("10000000000000");
     tx.nonce = U256::from(get_account_nonce(&DEFAULT_ACCOUNT).unwrap());
     match spec {
         Either::Left(data) => tx.data = data,
-        Either::Right(addr) => tx.action = Action::Call(addr),
+        Either::Right((addr, data)) => {
+            tx.action = Action::Call(addr);
+            tx.data = data;
+        }
     };
     tx.sign(&SECRET_KEY, None)
 }
 
-fn run(tx: SignedTransaction) -> Receipt {
+/// Runs a signed transaction using the runtime.
+pub fn run_tx(tx: SignedTransaction) -> Result<Receipt, ExecuteTransactionResponse> {
     let res = execute_raw_transaction(&rlp::encode(&tx).to_vec()).unwrap();
     let receipt = get_receipt(res.hash.as_ref().unwrap()).unwrap().unwrap();
     if !receipt.status_code.is_some() || receipt.status_code.unwrap() == 0 {
-        panic!("{:?}", &res);
+        println!("ERROR:\n{:?}\n{:?}", res, receipt);
+        Err(res)
+    } else {
+        Ok(receipt)
     }
-    receipt
-}
-
-fn main() {
-    let args = app_from_crate!()
-        .arg(
-            Arg::with_name("contract")
-                .help("path to file containing contract bytecode")
-                .required(true)
-                .index(1),
-        )
-        .arg(
-            Arg::with_name("dump-tx")
-                .long("dump-tx")
-                .value_name("FILE")
-                .help("dump RLP-encoded transaction to file")
-                .takes_value(true),
-        )
-        .get_matches();
-
-    let contract = fs::read(args.value_of("contract").unwrap()).unwrap();
-    let create_tx = make_tx(Either::Left(contract));
-    if let Some(tx_file) = args.value_of("dump-tx") {
-        fs::write(tx_file, rlp::encode(&create_tx)).unwrap();
-    }
-    println!("\nDeploying contract...\n=====================");
-    let create_receipt = run(create_tx);
-    let contract_addr = create_receipt.contract_address.unwrap();
-    println!("\nCalling contract...\n=====================");
-    println!("{:?}", run(make_tx(Either::Right(contract_addr))))
 }


### PR DESCRIPTION
This PR separates the run-contract utility into a library and a binary. The binary works as before but the lib allows unit testing in other crates (e.g., testing x-contract calls)