### PR TITLE
Increase max_code_size

### DIFF
--- a/resources/genesis/genesis.json
+++ b/resources/genesis/genesis.json
@@ -10,7 +10,7 @@
     "maximumExtraDataSize": "0x20",
     "minGasLimit": "0x1388",
     "networkID" : "0xa515",
-    "maxCodeSize": 24576,
+    "maxCodeSize": 4294967296,
     "maxCodeSizeTransition": "0x0",
     "eip86Transition": "0xffffffffffffffff",
     "eip98Transition": "0xffffffffffffffff",

--- a/resources/genesis/genesis_benchmarking.json
+++ b/resources/genesis/genesis_benchmarking.json
@@ -11,7 +11,7 @@
     "maximumExtraDataSize": "0x20",
     "minGasLimit": "0x1388",
     "networkID" : "0xa515",
-    "maxCodeSize": 24576,
+    "maxCodeSize": 4294967296,
     "maxCodeSizeTransition": "0x0",
     "eip86Transition": "0xffffffffffffffff",
     "eip98Transition": "0xffffffffffffffff",


### PR DESCRIPTION
This seems to be the only change needed to get wasm contracts working under gas-accounted EVM.