### PR TITLE
estimateGas: return gas_used + refunded

### DIFF
--- a/api/src/state.rs
+++ b/api/src/state.rs
@@ -102,4 +102,5 @@ pub struct ExecuteTransactionResponse {
 pub struct SimulateTransactionResponse {
     pub result: Result<Vec<u8>, String>,
     pub used_gas: U256,
+    pub refunded_gas: U256,
 }

--- a/gateway/src/client.rs
+++ b/gateway/src/client.rs
@@ -492,8 +492,12 @@ impl Client {
         let options = TransactOptions::with_no_tracing()
             .dont_check_nonce()
             .save_output_from_contract();
-        let ret =
-            Executive::new(&mut state, &env_info, machine, &*self.storage.read().unwrap()).transact_virtual(transaction, options)?;
+        let ret = Executive::new(
+            &mut state,
+            &env_info,
+            machine,
+            &*self.storage.read().unwrap(),
+        ).transact_virtual(transaction, options)?;
         Ok(ret)
     }
 
@@ -535,9 +539,13 @@ impl Client {
         let options = TransactOptions::with_no_tracing()
             .dont_check_nonce()
             .save_output_from_contract();
-        let ret =
-            Executive::new(&mut state, &env_info, machine, &*self.storage.read().unwrap()).transact_virtual(transaction, options)?;
-        Ok(ret.gas_used)
+        let ret = Executive::new(
+            &mut state,
+            &env_info,
+            machine,
+            &*self.storage.read().unwrap(),
+        ).transact_virtual(transaction, options)?;
+        Ok(ret.gas_used + ret.refunded)
     }
 
     #[cfg(not(feature = "read_state"))]
@@ -547,7 +555,7 @@ impl Client {
             self.client
                 .simulate_transaction(request)
                 .wait()
-                .map(|r| Ok(r.used_gas)),
+                .map(|r| Ok(r.used_gas + r.refunded_gas)),
             Err("no response from runtime".to_string()),
         )
     }

--- a/gateway/src/storage.rs
+++ b/gateway/src/storage.rs
@@ -3,21 +3,19 @@ use ekiden_common::futures::FutureExt;
 use ekiden_core::futures::Future;
 use ekiden_storage_base::{hash_storage_key, StorageBackend};
 use ethcore::storage::Storage;
-use vm::{Error, Result};
 use ethereum_types::H256;
+use vm::{Error, Result};
 
 use std::str::FromStr;
 use std::sync::Arc;
 
-pub struct Web3GlobalStorage{
+pub struct Web3GlobalStorage {
     backend: Arc<StorageBackend>,
 }
 
 impl Web3GlobalStorage {
     pub fn new(backend: Arc<StorageBackend>) -> Self {
-        Web3GlobalStorage {
-            backend: backend,
-        }
+        Web3GlobalStorage { backend: backend }
     }
 }
 
@@ -30,7 +28,9 @@ impl Storage for Web3GlobalStorage {
     }
 
     fn store_bytes(&self, bytes: &[u8]) -> Result<H256> {
-        let result = self.backend.insert(bytes.to_vec(), <u64>::max_value()).wait();
+        let result = self.backend
+            .insert(bytes.to_vec(), <u64>::max_value())
+            .wait();
         match result {
             Ok(_) => Ok(H256::from_slice(&hash_storage_key(bytes).0)),
             Err(err) => Err(Error::Storage(err.description().to_string())),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -271,6 +271,7 @@ pub fn simulate_transaction(request: &TransactionRequest) -> Result<SimulateTran
         Err(e) => {
             return Ok(SimulateTransactionResponse {
                 used_gas: U256::from(0),
+                refunded_gas: U256::from(0),
                 result: Err(e.to_string()),
             })
         }
@@ -280,12 +281,14 @@ pub fn simulate_transaction(request: &TransactionRequest) -> Result<SimulateTran
         Err(e) => {
             return Ok(SimulateTransactionResponse {
                 used_gas: U256::from(0),
+                refunded_gas: U256::from(0),
                 result: Err(e.to_string()),
             })
         }
     };
     Ok(SimulateTransactionResponse {
         used_gas: exec.gas_used,
+        refunded_gas: exec.refunded,
         result: Ok(exec.output),
     })
 }


### PR DESCRIPTION
See #149 

The gas needed to successfully execute a transaction is actually the high water mark, which can be computed as `gas_used` + `refunded`. (https://github.com/paritytech/parity-ethereum/blob/9caa8686039c5f5c830ac3bf770e9c6ae2a47173/ethcore/src/executed.rs#L42)