### PR TITLE
Increase epoch interval in end-to-end tests to avoid transitions during tests

### DIFF
--- a/scripts/test-e2e.sh
+++ b/scripts/test-e2e.sh
@@ -29,7 +29,7 @@ run_dummy_node_go_tm() {
         --log.level debug \
         --grpc.port 42261 \
         --epochtime.backend tendermint \
-        --epochtime.tendermint.interval 30 \
+        --epochtime.tendermint.interval 90 \
         --beacon.backend tendermint \
         --storage.backend memory \
         --scheduler.backend trivial \


### PR DESCRIPTION
The current set of truffle tests take ~40 seconds to run, so we need an epoch interval longer than that to ensure that no transactions are issued during an epoch transition. Handling transactions issued during epoch transitions is an open issue (https://github.com/oasislabs/ekiden/issues/479). 