### PR TITLE
Add bin name for run-contract

### DIFF
--- a/tests/run_contract/Cargo.toml
+++ b/tests/run_contract/Cargo.toml
@@ -21,3 +21,7 @@ simple_logger = "0.5.0"
 
 [profile.release]
 debug-assertions = true
+
+[[bin]]
+name = "run-contract"
+path = "src/bin/main.rs"


### PR DESCRIPTION
`cargo install` currently installs this as `main`. We want it to install as `run-contract`.