### PR TITLE
deploy-to-production: correct docker image name & comment the deploy part

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,7 +231,7 @@ jobs:
 
       - run:
           name: Tag the ekiden build on this workflow for production
-          command: docker tag oasislabs/ekiden-runtime-ethereum:$BUILD_IMAGE_TAG oasislabs/runtime-ethereum:$PRODUCTION_TAG
+          command: docker tag oasislabs/ekiden-runtime-ethereum:$BUILD_IMAGE_TAG oasislabs/ekiden-runtime-ethereum:$PRODUCTION_TAG
 
       - run:
           name: Push the new production tag of ekiden to dockerhub


### PR DESCRIPTION
So we can use "promote-to-production" step to properly update the `latest` docker image.