### PR TITLE
TX client stability

### DIFF
--- a/docker/transactionclient/src/web3.js
+++ b/docker/transactionclient/src/web3.js
@@ -69,7 +69,7 @@ if (require.main === module) {
       process.exit(0);
     }
 
-    async function nextTxn (client) {
+    async function nextTxn () {
       let client = new web3();
       let hprovider = new client.providers.HttpProvider(process.argv[2], 1000 * 60);
       let provider = new HDWalletProvider(mnemonic, hprovider);


### PR DESCRIPTION
this causes a new web3 client to be created for each request, and if too many requests built up the client will restart itself.