### PR TITLE
CircleCI workflow optimizations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -275,9 +275,6 @@ jobs:
       - checkout
 
       - run:
-          name: Check source code style
-          command: cargo fmt -- --write-mode=check
-      - run:
           name: Install ekiden-tools
           command: cargo install
                      --git https://github.com/oasislabs/ekiden


### PR DESCRIPTION
Refactor CircleCI configuration to run non-dependent jobs in parallel.

These changes were [tested](https://circleci.com/workflow-run/7116481c-e249-4e88-8d32-a76e6b5dcb66) and result in a 77% reduction in workflow run times (~53 minutes to ~12 minutes).

Question: this PR runs the `build-and-publish-docker-image` job in parallel with other jobs that build code in debug mode. This saves a massive amount of time (~20 minutes) in the workflow, but does have some tradeoffs. A con is that it results in a docker image getting published to Docker Hub even if some of the other jobs fail to compile code. Since Docker Hub allows unlimited storage, that might not be the worst thing in the world. A pro that @ravenac95 pointed out is that the Docker images are available for PRs for someone to use the Docker images locally for testing, they can easily pull it down from Docker Hub.

Updates https://github.com/oasislabs/private-ops/issues/312.