### PR TITLE
gateway: handle pending blocks as a special case in eth_blockTransactionCountByNumber

### DIFF
--- a/gateway/src/impls/eth.rs
+++ b/gateway/src/impls/eth.rs
@@ -376,11 +376,13 @@ impl Eth for EthClient {
     fn block_transaction_count_by_number(&self, num: BlockNumber) -> BoxFuture<Option<RpcU256>> {
         measure_counter_inc!("getBlockTransactionCountByNumber");
         info!("eth_getBlockTransactionCountByNumber(number: {:?})", num);
-        Box::new(future::ok(
-            self.client
+        Box::new(future::ok(match num {
+            // we don't have pending blocks
+            BlockNumber::Pending => Some(RpcU256::from(0)),
+            _ => self.client
                 .block(block_number_to_id(num))
                 .map(|block| block.transactions_count().into()),
-        ))
+        }))
     }
 
     fn block_uncles_count_by_hash(&self, _hash: RpcH256) -> BoxFuture<Option<RpcU256>> {


### PR DESCRIPTION
A geth rpc test crashed the gateway on this line:

https://github.com/oasislabs/parity/blob/1318f536c9d13acc1740b401e304e9b88a540d87/rpc/src/v1/types/block_number.rs#L101