### PR TITLE
ci: build run-contract

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -528,6 +528,7 @@ workflows:
       - build-web3-gateway-benchmark
       - build-genesis
       - build-playback
+      - build-run-contract
       - end-to-end-tests:
           requires:
             - build-go
@@ -554,6 +555,7 @@ workflows:
             - build-web3-gateway-benchmark
             - build-genesis
             - build-playback
+            - build-run-contract
       - hold-for-production:
           type: approval
           filters:

--- a/tests/run_contract/src/bin/main.rs
+++ b/tests/run_contract/src/bin/main.rs
@@ -40,7 +40,7 @@ fn main() {
                 .long("call-args")
                 .help("Arguments to be passed to contract call")
                 .takes_value(true)
-                .default_value("")
+                .default_value(""),
         )
         .get_matches();
 

--- a/tests/run_contract/src/lib.rs
+++ b/tests/run_contract/src/lib.rs
@@ -15,7 +15,7 @@ use std::str::FromStr;
 use either::Either;
 use ekiden_roothash_base::Header;
 use ekiden_trusted::{contract::dispatcher::{BatchHandler, ContractCallContext},
-                     db::DatabaseHandle};
+                     db::{Database, DatabaseHandle}};
 use ethcore::{rlp,
               storage::Storage,
               transaction::{Action, SignedTransaction, Transaction}};


### PR DESCRIPTION
We forgot to actually build run-contract when refactoring the CI flow