### PR TITLE
Conorgil/bugfix/tag staging images in staging deploy job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -586,11 +586,19 @@ workflows:
             - build-go
             - build-and-test-runtime
             - build-and-test-web3-gateway
+      - manual-approval-on-non-master-branches:
+          # This job requires manual approval in
+          # the CircleCI on non-master branches.
+          type: approval
+          filters:
+            branches:
+              ignore: master
       - build-and-publish-docker-image:
           # This job does *not* require most other jobs
           # so this job can run in parallel.
           requires:
             - set-docker-tag
+            - manual-approval-on-non-master-branches
       - deploy-to-staging:
           filters:
             branches:


### PR DESCRIPTION
Update the CircleCI jobs to only apply the 'staging' tag to the image in the `deploy-to-staging` job.

Fixes https://github.com/oasislabs/runtime-ethereum/issues/276