### PR TITLE
[DO NOT MERGE] Testing CircleCI approval jobs within workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ workflows:
           type: approval
           filters:
             branches:
-              ignore: master
+              ignore: conorgil/feature/testing-circleci-approval-workflows
       - jobB:
           requires:
             - approve-jobB


### PR DESCRIPTION
This PR is only intended for testing CircleCI functionality and SHOULD NOT BE MERGED. I would have created another project entirely, but I don't have permission in CircleCI to do that right now. I am creating this PR so that I can comment on my findings and share screenshots of the behavior I observe.

    I am trying to udnerstand how/if I can configure
    an approval job to only run on certain branches.
    If a job requires an approval and that approval
    has a filter that ignores certain branches, then
    can the workflow complete on matching branches
    since the approval will never run?