### PR TITLE
run-contract: remove useless print statement

### DIFF
--- a/tests/run_contract/src/bin/main.rs
+++ b/tests/run_contract/src/bin/main.rs
@@ -51,7 +51,6 @@ fn main() {
         _ => log::Level::Trace,
     }).expect("cound not init simple_logger");
 
-    println!("{:?}", store_bytes(&[1, 2, 3, 4, 5]));
     let contract = fs::read(args.value_of("contract").unwrap()).unwrap();
     let create_tx = make_tx(Either::Left(contract));
     if let Some(tx_file) = args.value_of("dump-tx") {


### PR DESCRIPTION
@david-yan 