### PR TITLE
gateway: change panic strategy to abort for release builds

### DIFF
--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -77,6 +77,9 @@ ekiden-storage-dummy = { git = "https://github.com/oasislabs/ekiden", branch = "
 ekiden-storage-frontend = { git = "https://github.com/oasislabs/ekiden", branch = "master" }
 hex = "0.3"
 
+[profile.release]
+panic = "abort"
+
 [patch.crates-io]
 ring = { git = "https://github.com/oasislabs/ring", branch = "0.12.1-ekiden" }
 


### PR DESCRIPTION
See #298 

Confirmed that we still get a backtrace in the logs as long as `RUST_BACKTRACE` is set (https://github.com/oasislabs/private-ops/blob/9a1ccc3529a37752ffff9dd2c0faa00d6efadd66/k8s/ekiden/templates/gateway.yaml#L30).