### PR TITLE
Inject encrypter and keymanager into parity state from gateway

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ runtime-ethereum-common = { path = "./common" }
 common-types = { git = "https://github.com/oasislabs/parity", branch = "ekiden" }
 ekiden-common = { git = "https://github.com/oasislabs/ekiden", branch = "master" }
 ekiden-core = { git = "https://github.com/oasislabs/ekiden", branch = "master" }
-ekiden-keymanager-common = { git = "https://github.com/oasislabs/ekiden", branch = "master" }
 ekiden-trusted = { git = "https://github.com/oasislabs/ekiden", branch = "master" }
 ekiden-storage-base = { git = "https://github.com/oasislabs/ekiden", branch = "master" }
 ekiden-storage-dummy = { git = "https://github.com/oasislabs/ekiden", branch = "master" }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Oasis Labs Inc. <info@oasislabs.com>"]
 
 [dependencies]
 ekiden-core = { git = "https://github.com/oasislabs/ekiden", branch = "master" }
+ekiden-keymanager-common = { git = "https://github.com/oasislabs/ekiden", branch = "master" }
 ekiden-storage-base = { git = "https://github.com/oasislabs/ekiden", branch = "master" }
 ekiden-storage-lru = { git = "https://github.com/oasislabs/ekiden", branch = "master" }
 ekiden-trusted = { git = "https://github.com/oasislabs/ekiden", branch = "master" }

--- a/common/src/confidential.rs
+++ b/common/src/confidential.rs
@@ -1,0 +1,45 @@
+use ekiden_keymanager_common::confidential;
+use ekiden_core::mrae::sivaessha2::NONCE_SIZE;
+use ethcore::state::{Encrypter as EthEncrypter, KeyManager as EthKeyManager};
+use ethereum_types::Address;
+
+/// Implementation of the parity KeyManager trait to inject into the ConfidentialVm.
+pub struct KeyManager;
+impl EthKeyManager for KeyManager {
+    fn long_term_public_key(&self, contract: Address) -> Vec<u8> {
+        let (pk, _sk) = confidential::default_contract_keys();
+        pk.to_vec()
+    }
+}
+
+/// Implementation of the Encrypter trait to inject into parity for confidential contracts.
+pub struct Encrypter;
+impl EthEncrypter for Encrypter {
+    fn encrypt(
+        &self,
+        plaintext: Vec<u8>,
+        peer_public_key: Vec<u8>,
+    ) -> Result<Vec<u8>, String> {
+        if peer_public_key.len() < 32 {
+            return Err("public keys must be 32 bytes long".to_string());
+        }
+        // just generate arbitrary nonce for now (change this to a random nonce once we encrypt
+        // with an actual key manager)
+        let mut nonce = [1u8; NONCE_SIZE];
+        let mut pub_key: [u8; 32] = Default::default();
+        pub_key.copy_from_slice(&peer_public_key[..32]);
+        confidential::encrypt(plaintext, nonce.to_vec(), pub_key)
+            .map_err(|_| "could not decrypt".to_string())
+    }
+
+    /// Returns a tuple containing the nonce, public key, and plaintext
+    /// used to generate the given cypher.
+    fn decrypt(&self, cypher: Vec<u8>) -> Result<(Vec<u8>, Vec<u8>, Vec<u8>), String> {
+        let decryption = confidential::decrypt(Some(cypher)).map_err(|_| "Error".to_string())?;
+        Ok((
+            decryption.nonce,
+            decryption.peer_public_key.to_vec(),
+            decryption.plaintext,
+        ))
+    }
+}

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -5,11 +5,14 @@ extern crate ekiden_core;
 extern crate ekiden_storage_base;
 extern crate ekiden_storage_lru;
 extern crate ekiden_trusted;
+extern crate ekiden_keymanager_common;
 extern crate elastic_array;
 extern crate ethcore;
 extern crate ethereum_types;
 extern crate hashdb;
 extern crate keccak_hash;
+
+pub mod confidential;
 
 use std::{collections::{hash_map::Entry, HashMap}, sync::{Arc, Mutex}};
 

--- a/gateway/src/state.rs
+++ b/gateway/src/state.rs
@@ -18,7 +18,8 @@ use rlp_compress::{blocks_swapper, decompress};
 
 use ekiden_db_trusted::Database;
 use ekiden_storage_base::StorageBackend;
-pub use runtime_ethereum_common::State as EthState;
+pub use runtime_ethereum_common::{confidential::{Encrypter, KeyManager},
+                                  State as EthState};
 use runtime_ethereum_common::{get_factories, Backend, BlockchainStateDb, StorageHashDB};
 
 pub struct StateDb<T: Database + Send + Sync> {
@@ -214,8 +215,8 @@ where
             root,
             U256::zero(), /* account_start_nonce */
             get_factories(),
-            None,
-            None,
+            Some(Box::new(Encrypter)),
+            Some(Box::new(KeyManager)),
         ) {
             Ok(state) => Some(state),
             Err(e) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@
 extern crate common_types as ethcore_types;
 extern crate ekiden_common;
 extern crate ekiden_core;
-extern crate ekiden_keymanager_common;
 extern crate ekiden_storage_base;
 extern crate ekiden_storage_dummy;
 extern crate ekiden_storage_lru;
@@ -34,7 +33,6 @@ mod storage;
 use std::sync::Arc;
 
 use ekiden_core::error::{Error, Result};
-use ekiden_keymanager_common::confidential;
 use ekiden_storage_base::StorageBackend;
 #[cfg(not(target_env = "sgx"))]
 use ekiden_storage_dummy::DummyStorageBackend;

--- a/src/state.rs
+++ b/src/state.rs
@@ -3,8 +3,7 @@ use std::{self,
           sync::{Arc, Mutex}};
 
 use super::evm::{get_contract_address, GAS_LIMIT, SPEC};
-use ekiden_core::{self, error::Result, mrae::sivaessha2::NONCE_SIZE};
-use ekiden_keymanager_common::confidential;
+use ekiden_core::{self, error::Result};
 use ekiden_storage_base::StorageBackend;
 use ekiden_trusted::db::{Database, DatabaseHandle};
 use ethcore::{self,
@@ -15,7 +14,7 @@ use ethcore::{self,
               filter::Filter as EthcoreFilter,
               header::Header,
               kvdb::{self, KeyValueDB},
-              state::{backend::Wrapped as WrappedBackend, Encrypter, KeyManager},
+              state::backend::Wrapped as WrappedBackend,
               transaction::Action,
               types::{ids::BlockId,
                       log_entry::{LocalizedLogEntry, LogEntry},
@@ -23,7 +22,12 @@ use ethcore::{self,
                       BlockNumber}};
 use ethereum_api::{BlockId as EkidenBlockId, Filter, Log, Receipt, Transaction};
 use ethereum_types::{Address, H256, U256};
-use runtime_ethereum_common::{get_factories, Backend, BlockchainStateDb, State, StorageHashDB};
+use runtime_ethereum_common::{confidential::{Encrypter, KeyManager},
+                              get_factories,
+                              Backend,
+                              BlockchainStateDb,
+                              State,
+                              StorageHashDB};
 
 lazy_static! {
     static ref GLOBAL_CACHE: Mutex<Option<Cache>> = Mutex::new(None);
@@ -116,8 +120,8 @@ impl Cache {
             root,
             U256::zero(), /* account_start_nonce */
             get_factories(),
-            Some(Box::new(_Encrypter)),
-            Some(Box::new(_KeyManager)),
+            Some(Box::new(Encrypter)),
+            Some(Box::new(KeyManager)),
         )?)
     }
 
@@ -135,8 +139,8 @@ impl Cache {
             vec![],                           /* extra data */
             true,                             /* is epoch_begin */
             &mut Vec::new().into_iter(),      /* ancestry */
-            Some(Box::new(_Encrypter)),
-            Some(Box::new(_KeyManager)),
+            Some(Box::new(Encrypter)),
+            Some(Box::new(KeyManager)),
         )?)
     }
 
@@ -329,47 +333,6 @@ impl Cache {
 
     pub fn best_block_header(&self) -> Header {
         self.chain.best_block_header()
-    }
-}
-
-/// Implementation of the parity KeyManager trait to inject into the ConfidentialVm.
-struct _KeyManager;
-impl KeyManager for _KeyManager {
-    fn long_term_public_key(&self, contract: Address) -> Vec<u8> {
-        let (pk, _sk) = confidential::default_contract_keys();
-        pk.to_vec()
-    }
-}
-
-/// Implementation of the Encrypter trait to inject into parity for confidential contracts.
-struct _Encrypter;
-impl Encrypter for _Encrypter {
-    fn encrypt(
-        &self,
-        plaintext: Vec<u8>,
-        peer_public_key: Vec<u8>,
-    ) -> std::result::Result<Vec<u8>, String> {
-        if peer_public_key.len() < 32 {
-            return Err("public keys must be 32 bytes long".to_string());
-        }
-        // just generate arbitrary nonce for now (change this to a random nonce once we encrypt
-        // with an actual key manager)
-        let mut nonce = [1u8; NONCE_SIZE];
-        let mut pub_key: [u8; 32] = Default::default();
-        pub_key.copy_from_slice(&peer_public_key[..32]);
-        confidential::encrypt(plaintext, nonce.to_vec(), pub_key)
-            .map_err(|_| "could not decrypt".to_string())
-    }
-
-    /// Returns a tuple containing the nonce, public key, and plaintext
-    /// used to generate the given cypher.
-    fn decrypt(&self, cypher: Vec<u8>) -> std::result::Result<(Vec<u8>, Vec<u8>, Vec<u8>), String> {
-        let decryption = confidential::decrypt(Some(cypher)).map_err(|_| "Error".to_string())?;
-        Ok((
-            decryption.nonce,
-            decryption.peer_public_key.to_vec(),
-            decryption.plaintext,
-        ))
     }
 }
 


### PR DESCRIPTION
Pulls out the KeyManager and Encrypter structs from the runtime crate to the runtime-common crate so that they can be used in the gateway.