### PR TITLE
Disable ens tests

### DIFF
--- a/scripts/test-dapps.sh
+++ b/scripts/test-dapps.sh
@@ -32,7 +32,8 @@ run_test() {
 }
 
 run_dapps() {
-    run_ens
+    #run_ens
+    :
 }
 
 run_ens() {


### PR DESCRIPTION
We should disable these tests until https://github.com/oasislabs/runtime-ethereum/issues/349 is addressed.