### PR TITLE
Update wasm-build flag

### DIFF
--- a/tests/contracts/basic_wasm_contract/build.sh
+++ b/tests/contracts/basic_wasm_contract/build.sh
@@ -1,2 +1,2 @@
 cargo build --target wasm32-unknown-unknown --release
-wasm-build --target wasm32-unknown-unknown --stack-size 4194304 ../../../target basic_contract
+wasm-build --target wasm32-unknown-unknown --max-mem 4194304 ../../../target basic_contract

--- a/tests/contracts/rust-logistic-contract/build.sh
+++ b/tests/contracts/rust-logistic-contract/build.sh
@@ -1,2 +1,2 @@
 cargo build --target wasm32-unknown-unknown --release
-wasm-build --target wasm32-unknown-unknown --stack-size 262144 ../../../target rust_logistic_contract
+wasm-build --target wasm32-unknown-unknown --max-mem 262144 ../../../target rust_logistic_contract

--- a/tests/contracts/storage_contract/build.sh
+++ b/tests/contracts/storage_contract/build.sh
@@ -1,2 +1,2 @@
 cargo build --target wasm32-unknown-unknown --release
-wasm-build --target wasm32-unknown-unknown --stack-size 4194304 ../../../target storage_contract
+wasm-build --target wasm32-unknown-unknown --max-mem 4194304 ../../../target storage_contract


### PR DESCRIPTION
CircleCI will fail because of this change: https://github.com/oasislabs/wasm-utils/pull/2