### PR TITLE
scripts: Fix all the `set-epoch` calls for the refactor

### DIFF
--- a/scripts/benchmarks/genesis.sh
+++ b/scripts/benchmarks/genesis.sh
@@ -6,9 +6,9 @@ run_dummy_node_default() {
     echo "Starting dummy node."
 
     ekiden-node-dummy \
-	--random-beacon-backend dummy \
-	--entity-ethereum-address 0000000000000000000000000000000000000000 \
-	--time-source-notifier mockrpc \
+        --random-beacon-backend dummy \
+        --entity-ethereum-address 0000000000000000000000000000000000000000 \
+        --time-source-notifier mockrpc \
         --storage-backend dummy \
         &> dummy.log &
 }
@@ -38,9 +38,9 @@ run_compute_node_default() {
 
     ekiden-compute \
         --no-persist-identity \
-	--max-batch-timeout 10 \
-	--time-source-notifier system \
-	--entity-ethereum-address 0000000000000000000000000000000000000000 \
+        --max-batch-timeout 10 \
+        --time-source-notifier system \
+        --entity-ethereum-address 0000000000000000000000000000000000000000 \
         --storage-backend remote \
         --port ${port} \
         ${extra_args} \
@@ -61,9 +61,9 @@ run_compute_node_storage_multilayer() {
     ekiden-compute \
         --no-persist-identity \
         --max-batch-size 50 \
-	--max-batch-timeout 10 \
+        --max-batch-timeout 10 \
         --time-source-notifier system \
-	--entity-ethereum-address 0000000000000000000000000000000000000000 \
+        --entity-ethereum-address 0000000000000000000000000000000000000000 \
         --storage-backend multilayer \
         --storage-multilayer-local-storage-base "$db_dir" \
         --storage-multilayer-aws-region us-east-1 \
@@ -92,7 +92,7 @@ run_test() {
     # Advance epoch to elect a new committee.
     echo "Advancing epoch."
     sleep 2
-    ekiden-node-dummy-controller set-epoch --epoch 1
+    ekiden-node debug dummy set-epoch --epoch 1
     sleep 2
 
     # Start genesis state injector.
@@ -100,7 +100,7 @@ run_test() {
     ${WORKDIR}/genesis/target/release/genesis \
         --storage-backend remote \
         --mr-enclave $(cat ${WORKDIR}/target_benchmark/enclave/runtime-ethereum.mrenclave) \
-	${WORKDIR}/genesis/state-999999.json &
+        ${WORKDIR}/genesis/state-999999.json &
     genesis_pid=$!
 
     # Wait on genesis.

--- a/scripts/benchmarks/playback_e2e.sh
+++ b/scripts/benchmarks/playback_e2e.sh
@@ -6,9 +6,9 @@ run_dummy_node_default() {
     echo "Starting dummy node."
 
     ekiden-node-dummy \
-	--random-beacon-backend dummy \
-	--entity-ethereum-address 0000000000000000000000000000000000000000 \
-	--time-source-notifier mockrpc \
+        --random-beacon-backend dummy \
+        --entity-ethereum-address 0000000000000000000000000000000000000000 \
+        --time-source-notifier mockrpc \
         --storage-backend dummy \
         &> dummy.log &
 }
@@ -25,13 +25,13 @@ run_compute_node() {
 
     ekiden-compute \
         --no-persist-identity \
-	--max-batch-timeout 100 \
-	--max-batch-size 50 \
+        --max-batch-timeout 100 \
+        --max-batch-size 50 \
         --storage-backend multilayer \
         --storage-multilayer-local-storage-base /tmp/ekiden-storage-persistent_${id} \
         --storage-multilayer-bottom-backend remote \
-	--time-source-notifier system \
-	--entity-ethereum-address 0000000000000000000000000000000000000000 \
+        --time-source-notifier system \
+        --entity-ethereum-address 0000000000000000000000000000000000000000 \
         --port ${port} \
         ${extra_args} \
         ${WORKDIR}/target_benchmark/enclave/runtime-ethereum.so &> compute${id}.log &
@@ -55,7 +55,7 @@ run_test() {
     # Advance epoch to elect a new committee.
     echo "Advancing epoch."
     sleep 2
-    ekiden-node-dummy-controller set-epoch --epoch 1
+    ekiden-node debug dummy set-epoch --epoch 1
     sleep 2
 
     # Start genesis state injector.
@@ -63,7 +63,7 @@ run_test() {
     ${WORKDIR}/genesis/target/release/genesis \
         --storage-backend remote \
         --mr-enclave $(cat target_benchmark/enclave/runtime-ethereum.mrenclave) \
-	${WORKDIR}/genesis/state-9999.json &> genesis.log &
+        ${WORKDIR}/genesis/state-9999.json &> genesis.log &
     genesis_pid=$!
 
     # Wait on genesis.
@@ -80,9 +80,9 @@ run_test() {
     # Run transaction playback.
     echo "Starting transaction playback."
     ${WORKDIR}/playback/target/release/playback \
-	--transactions 10000 \
-	--threads 100 \
-	${WORKDIR}/playback/blocks-10000-1000000.bin &> playback.log &
+        --transactions 10000 \
+        --threads 100 \
+        ${WORKDIR}/playback/blocks-10000-1000000.bin &> playback.log &
     playback_pid=$!
 
     # Wait on playback.

--- a/scripts/benchmarks/web3_microbenchmark.sh
+++ b/scripts/benchmarks/web3_microbenchmark.sh
@@ -41,7 +41,7 @@ run_compute_node() {
         --max-batch-size 50 \
         --max-batch-timeout 100 \
         --entity-ethereum-address 0000000000000000000000000000000000000000 \
-	--disable-key-manager \
+        --disable-key-manager \
         --port ${port} \
         ${extra_args} \
         ${WORKDIR}/target_benchmark/enclave/runtime-ethereum.so &> compute${id}.log &

--- a/scripts/gateway.sh
+++ b/scripts/gateway.sh
@@ -62,7 +62,7 @@ run_test() {
     sleep 2
 
     # Advance epoch to elect a new committee.
-    ekiden dummy set-epoch --epoch 1
+    ekiden debug dummy set-epoch --epoch 1
 
     # Run the client. We run the client first so that we test whether it waits for the
     # committee to be elected and connects to the leader.
@@ -72,6 +72,7 @@ run_test() {
         --storage-multilayer-local-storage-base /tmp/ekiden-storage-persistent-gateway \
         --storage-multilayer-bottom-backend remote \
         --mr-enclave $(cat $WORKDIR/target/enclave/runtime-ethereum.mrenclave) \
+        --ws-max-connections 10000 \
         --threads 100 &> gateway.log &
     gateway_pid=$!
 

--- a/scripts/test-basic-wasm.sh
+++ b/scripts/test-basic-wasm.sh
@@ -25,7 +25,7 @@ run_test() {
     run_gateway 1
     sleep 10
 
-    ${WORKDIR}/ekiden-node dummy set-epoch --epoch 1
+    ${WORKDIR}/ekiden-node debug dummy set-epoch --epoch 1
 
     echo "Installing deploy_contract dependencies."
     pushd ${WORKDIR}/tests/deploy_contract > /dev/null

--- a/scripts/test-dapp.sh
+++ b/scripts/test-dapp.sh
@@ -21,7 +21,7 @@ run_test() {
     sleep 1
 
     # Advance epoch to elect a new commitee
-    ${WORKDIR}/ekiden-node dummy set-epoch --epoch 1
+    ${WORKDIR}/ekiden-node debug dummy set-epoch --epoch 1
 
     # Location for all the dapp repos
     mkdir -p /tmp/dapps

--- a/scripts/test-e2e.sh
+++ b/scripts/test-e2e.sh
@@ -29,7 +29,7 @@ run_test() {
 
     # Advance epoch to elect a new committee.
     sleep 3
-    ${WORKDIR}/ekiden-node dummy set-epoch --epoch 1
+    ${WORKDIR}/ekiden-node debug dummy set-epoch --epoch 1
 
     # Run truffle tests against gateway 1 (in background)
     echo "Running truffle tests."

--- a/scripts/test-pubsub.sh
+++ b/scripts/test-pubsub.sh
@@ -20,7 +20,7 @@ run_test() {
     run_gateway 1
     sleep 10
 
-    ${WORKDIR}/ekiden-node dummy set-epoch --epoch 1
+    ${WORKDIR}/ekiden-node debug dummy set-epoch --epoch 1
 
     echo "Running truffle tests."
     pushd ${WORKDIR}/tests > /dev/null

--- a/scripts/test-rpc.sh
+++ b/scripts/test-rpc.sh
@@ -86,7 +86,7 @@ run_test() {
     run_gateway 1
     sleep 3
 
-    ${WORKDIR}/ekiden-node dummy set-epoch --epoch 1
+    ${WORKDIR}/ekiden-node debug dummy set-epoch --epoch 1
 
     echo "Installing RPC test dependencies."
     pushd ${WORKDIR}/tests/ > /dev/null

--- a/scripts/test-storage.sh
+++ b/scripts/test-storage.sh
@@ -25,7 +25,7 @@ run_test() {
     run_gateway 1
     sleep 10
 
-    ${WORKDIR}/ekiden-node dummy set-epoch --epoch 1
+    ${WORKDIR}/ekiden-node debug dummy set-epoch --epoch 1
 
     echo "Uploading bytes to storage."
     curl -X POST -H 'Content-Type: application/json' --data '{"jsonrpc":"2.0","method":"oasis_storeBytes","params":[[1, 2, 3, 4, 5], 9223372036854775807],"id":"1"}' localhost:8545 > /dev/null

--- a/scripts/test-web3cjs.sh
+++ b/scripts/test-web3cjs.sh
@@ -20,7 +20,7 @@ run_test() {
     sleep 1
 
     # Advance epoch to elect a new commitee
-    ${WORKDIR}/ekiden-node dummy set-epoch --epoch 1
+    ${WORKDIR}/ekiden-node debug dummy set-epoch --epoch 1
 
     mkdir -p /tmp/testing
 

--- a/scripts/test_rust_logistic.sh
+++ b/scripts/test_rust_logistic.sh
@@ -25,7 +25,7 @@ run_test() {
     run_gateway 1
     sleep 10
 
-    ${WORKDIR}/ekiden-node dummy set-epoch --epoch 1
+    ${WORKDIR}/ekiden-node debug dummy set-epoch --epoch 1
 
     echo "Installing deploy_contract dependencies."
     pushd ${WORKDIR}/tests/deploy_contract > /dev/null


### PR DESCRIPTION
 * The scripts in `benchmarks/` were even futher rotted and were
   attempting to advance the epoch with a non-existent executable.

Requires oasislabs/ekiden#1157.