### PR TITLE
gateway: remove patch section from Cargo.toml, as it is not used and no longer needed

### DIFF
--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -77,18 +77,6 @@ ekiden-storage-dummy = { git = "https://github.com/oasislabs/ekiden", branch = "
 ekiden-storage-frontend = { git = "https://github.com/oasislabs/ekiden", branch = "master" }
 hex = "0.3"
 
-[patch.crates-io]
-ring = { git = "https://github.com/oasislabs/ring", branch = "0.12.1-ekiden" }
-
-# temporary fix for incompatibility between jsonrpc-ipc-server parity-1.11 branch and parity-tokio-ipc
-[patch."https://github.com/paritytech/jsonrpc.git"]
-jsonrpc-core = { git = "https://github.com/oasislabs/jsonrpc.git", branch = "parity-1.11-ekiden" }
-jsonrpc-http-server = { git = "https://github.com/oasislabs/jsonrpc.git", branch = "parity-1.11-ekiden" }
-jsonrpc-ws-server = { git = "https://github.com/oasislabs/jsonrpc.git", branch = "parity-1.11-ekiden" }
-jsonrpc-ipc-server = { git = "https://github.com/oasislabs/jsonrpc.git", branch = "parity-1.11-ekiden" }
-jsonrpc-macros = { git = "https://github.com/oasislabs/jsonrpc.git", branch = "parity-1.11-ekiden" }
-jsonrpc-pubsub = { git = "https://github.com/oasislabs/jsonrpc.git", branch = "parity-1.11-ekiden" }
-
 [features]
 default = ["confidential", "pubsub"]
 pubsub = []


### PR DESCRIPTION
Our `jsonrpc` fork is no longer needed, as a fix has gone in upstream for the original issue: https://github.com/paritytech/jsonrpc/pull/306