### PR TITLE
instrumentation: fix measuring time in futures

### DIFF
--- a/gateway/src/impls/confidential.rs
+++ b/gateway/src/impls/confidential.rs
@@ -55,7 +55,6 @@ impl Confidential for ConfidentialClient {
         tag: Trailing<BlockNumber>,
     ) -> BoxFuture<Bytes> {
         measure_counter_inc!("confidential_call");
-        measure_histogram_timer!("confidential_call_enc_time");
         let num = tag.unwrap_or_default();
         info!(
             "confidential_call_enc(request: {:?}, number: {:?})",
@@ -71,11 +70,12 @@ impl Confidential for ConfidentialClient {
             value: request.value.map(Into::into),
             gas: request.gas.map(Into::into),
         };
-        Box::new(
+        Box::new(measure_future_histogram_timer!(
+            "confidential_call_enc_time",
             self.client
                 .call_enc(request, EthClient::get_block_id(num))
                 .map_err(errors::execution)
-                .map(Into::into),
-        )
+                .map(Into::into)
+        ))
     }
 }

--- a/gateway/src/impls/eth.rs
+++ b/gateway/src/impls/eth.rs
@@ -523,19 +523,19 @@ impl Eth for EthClient {
 
     fn send_raw_transaction(&self, raw: Bytes) -> BoxFuture<RpcH256> {
         measure_counter_inc!("sendRawTransaction");
-        measure_histogram_timer!("sendRawTransaction_time");
         if log_enabled!(log::Level::Debug) {
             debug!("eth_sendRawTransaction(data: {:?})", raw);
         } else {
             info!("eth_sendRawTransaction(data: ...)");
         }
 
-        Box::new(
+        Box::new(measure_future_histogram_timer!(
+            "sendRawTransaction_time",
             self.client
                 .send_raw_transaction(raw.into())
                 .map(Into::into)
-                .map_err(errors::execution),
-        )
+                .map_err(errors::execution)
+        ))
     }
 
     fn submit_transaction(&self, raw: Bytes) -> BoxFuture<RpcH256> {


### PR DESCRIPTION
Requires: https://github.com/oasislabs/ekiden/pull/1166 

`"call_time"` & `"estimateGas_time"` don't really need the fix. changed them for consistency (can also revert the change there)

Waiting for one more fix: https://github.com/oasislabs/ekiden/pull/1169