### PR TITLE
benchmarks: exit(1) in case benchmarks are not run

### DIFF
--- a/benchmark/cmd/benchmark_cmd.go
+++ b/benchmark/cmd/benchmark_cmd.go
@@ -106,6 +106,7 @@ func benchmarkMain(cmd *cobra.Command, args []string) {
 				"err", err,
 				"benchmark", benchmark.Name(),
 			)
+			os.Exit(1)
 		}
 	}
 


### PR DESCRIPTION
exits with error in case "failed to run benchmark" error happens