### PR TITLE
benchmarks/transfer: fix a dumb underflow

### DIFF
--- a/benchmark/benchmarks/transfer/transfer.go
+++ b/benchmark/benchmarks/transfer/transfer.go
@@ -69,6 +69,10 @@ func (account *transferAccount) drainTo(ctx context.Context, dst common.Address)
 	if err != nil {
 		return err
 	}
+	if balance.Cmp(&big.Int{}) <= 0 {
+		// Account balance is <= 0 already.
+		return nil
+	}
 
 	// Transfer off the remaining balance back to the funding account.
 	balance.Sub(balance, transferFee)


### PR DESCRIPTION
If the sub-account balance is already 0, there's no need to attempt to
drain it back to the funding account.