### PR TITLE
benchmarks: Add a `faucet` sub-command

### DIFF
--- a/benchmark/benchmarks/transfer/transfer.go
+++ b/benchmark/benchmarks/transfer/transfer.go
@@ -26,6 +26,10 @@ import (
 )
 
 const (
+	// FundingAccount is the account in the development environment
+	// genesis block that has a large amount of funds.
+	FundingAccount = "533d62aea9bbcb821dfdda14966bb01bfbbb53b7e9f5f0d69b8326e052e3450c"
+
 	cfgFaucetURL    = "benchmarks.transfer.faucet_url"
 	cfgWatchNewHead = "benchmarks.transfer.watch_new_head"
 
@@ -306,7 +310,7 @@ func (bench *benchTransfer) ensureMinBalance(ctx context.Context, states []*api.
 		return err
 	}
 
-	level.Debug(logger).Log("msg", "funding account balance",
+	_ = level.Debug(logger).Log("msg", "funding account balance",
 		"balance", balance,
 		"required_balance", &minBalance,
 	)
@@ -322,14 +326,14 @@ func (bench *benchTransfer) ensureMinBalance(ctx context.Context, states []*api.
 	}
 	u, err := url.Parse(flagFaucetURL)
 	if err != nil {
-		return fmt.Errorf("invalid faucet URL: ", err)
+		return fmt.Errorf("invalid faucet URL: %v", err)
 	}
 	q := u.Query()
 	q.Set("to", fundingAccountAddr.Hex())
 	q.Set("amnt", minBalance.String())
 	u.RawQuery = q.Encode()
 
-	level.Debug(logger).Log("msg", "requesting funding from faucet",
+	_ = level.Debug(logger).Log("msg", "requesting funding from faucet",
 		"url", u,
 	)
 
@@ -363,14 +367,8 @@ func Init(cmd *cobra.Command) {
 		viper.BindPFlag(v, cmd.Flags().Lookup(v)) // nolint: errcheck
 	}
 
-	// TODO: This probably shouldn't be hardcoded, but just initialize
-	// the funding account here for now.
-	const (
-		fundingAccount = "533d62aea9bbcb821dfdda14966bb01bfbbb53b7e9f5f0d69b8326e052e3450c"
-		fundingAddress = "0x7110316b618d20d0c44728ac2a3d683536ea682b"
-	)
-
-	privKey, err := crypto.HexToECDSA(fundingAccount)
+	const fundingAddress = "0x7110316b618d20d0c44728ac2a3d683536ea682b"
+	privKey, err := crypto.HexToECDSA(FundingAccount)
 	if err != nil {
 		panic(err)
 	}

--- a/benchmark/cmd/benchmark_cmd.go
+++ b/benchmark/cmd/benchmark_cmd.go
@@ -27,15 +27,15 @@ const (
 	cfgBenchmarksConcurrency = "benchmarks.concurrency"
 	cfgBenchmarksDuration    = "benchmarks.duration"
 
-	cfgLogLevel        = "log.level"
 	cfgLogVerboseDebug = "log.verbose_debug"
-	cfgLogFile         = "log.file"
 
 	cfgGatewayURL = "gateway_url"
 
 	cfgPrometheusPushAddr          = "prometheus.push.addr"
 	cfgPrometheusPushJobName       = "prometheus.push.job_name"
 	cfgPrometheusPushInstanceLabel = "prometheus.push.instance_label"
+
+	defaultGatewayURL = "ws://127.0.0.1:8546"
 )
 
 var (
@@ -43,9 +43,7 @@ var (
 	flagBenchmarksConcurrency uint
 	flagBenchmarksDuration    time.Duration
 
-	flagLogLevel        logLevel
 	flagLogVerboseDebug bool
-	flagLogFile         string
 
 	flagGatewayURL string
 
@@ -64,7 +62,7 @@ func benchmarkMain(cmd *cobra.Command, args []string) {
 
 	flagBenchmarks.deduplicate()
 	if len(flagBenchmarks.benchmarks) == 0 {
-		_ = level.Error(logger).Log("err", "insufficient benchmarks requested")
+		_ = level.Error(logger).Log("msg", "insufficient benchmarks requested")
 		os.Exit(1)
 	}
 
@@ -205,10 +203,8 @@ func benchmarkInit(cmd *cobra.Command) {
 	cmd.Flags().VarP(&flagBenchmarks, cfgBenchmarks, "b", "Benchmarks")
 	cmd.Flags().UintVar(&flagBenchmarksConcurrency, cfgBenchmarksConcurrency, 1, "Benchmark concurrency")
 	cmd.Flags().DurationVar(&flagBenchmarksDuration, cfgBenchmarksDuration, 30*time.Second, "Benchmark duration")
-	cmd.Flags().Var(&flagLogLevel, cfgLogLevel, "Log level")
 	cmd.Flags().BoolVar(&flagLogVerboseDebug, cfgLogVerboseDebug, false, "Extremely verbose debug logging")
-	cmd.Flags().StringVar(&flagLogFile, cfgLogFile, "", "Log file (default stdout)")
-	cmd.Flags().StringVar(&flagGatewayURL, cfgGatewayURL, "ws://127.0.0.1:8546", "JSON-RPC gateway URL")
+	cmd.Flags().StringVar(&flagGatewayURL, cfgGatewayURL, defaultGatewayURL, "JSON-RPC gateway URL")
 	cmd.Flags().StringVar(&flagPrometheusPushAddr, cfgPrometheusPushAddr, "", "Prometheus push gateway address")
 	cmd.Flags().StringVar(&flagPrometheusPushJobName, cfgPrometheusPushJobName, "", "Prometheus push `job` name")
 	cmd.Flags().StringVar(&flagPrometheusPushInstanceLabel, cfgPrometheusPushInstanceLabel, "", "Prometheus push `instance` label")
@@ -217,9 +213,7 @@ func benchmarkInit(cmd *cobra.Command) {
 		cfgBenchmarks,
 		cfgBenchmarksConcurrency,
 		cfgBenchmarksDuration,
-		cfgLogLevel,
 		cfgLogVerboseDebug,
-		cfgLogFile,
 		cfgGatewayURL,
 		cfgPrometheusPushAddr,
 		cfgPrometheusPushJobName,

--- a/benchmark/cmd/debug_faucet_lite.go
+++ b/benchmark/cmd/debug_faucet_lite.go
@@ -1,0 +1,192 @@
+package cmd
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"sync/atomic"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/oasislabs/runtime-ethereum/benchmark/benchmarks/transfer"
+)
+
+const (
+	cfgFaucetAddress = "faucet.address"
+)
+
+var (
+	faucetCmd = &cobra.Command{
+		Use:   "faucet",
+		Short: "Lite private faucet",
+		Run:   faucetMain,
+	}
+
+	flagFaucetAddress string
+
+	gasPrice = big.NewInt(1000000000)
+)
+
+func faucetMain(cmd *cobra.Command, args []string) {
+	w, err := initLogFile(cmd)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to initialize log file: %v", err)
+		os.Exit(1)
+	}
+	logger := flagLogLevel.GetLogger(w)
+
+	if err = runFaucetWorker(logger); err != nil {
+		_ = level.Error(logger).Log("msg", "faucet terminated",
+			"err", err,
+		)
+	}
+}
+
+type faucetWorker struct {
+	logger log.Logger
+
+	rpcClient *rpc.Client
+	client    *ethclient.Client
+
+	privateKey *ecdsa.PrivateKey
+	nonce      uint64
+}
+
+func (w *faucetWorker) handleRequest(resp http.ResponseWriter, req *http.Request) {
+	sendErrorResponse := func(statusCode int, err error) {
+		resp.WriteHeader(statusCode)
+		_, _ = io.WriteString(resp, "err")
+	}
+
+	toStr := req.URL.Query().Get("to")
+	to, err := parseHexAddress(toStr)
+	if err != nil {
+		_ = level.Warn(w.logger).Log("msg", "failed to parse to",
+			"to", toStr,
+		)
+		sendErrorResponse(http.StatusBadRequest, err)
+		return
+	}
+
+	amntStr := req.URL.Query().Get("amnt")
+	var amnt big.Int
+	if _, ok := amnt.SetString(amntStr, 0); !ok {
+		_ = level.Warn(w.logger).Log("msg", "failed to parse amnt",
+			"amnt", amntStr,
+		)
+		sendErrorResponse(http.StatusBadRequest, fmt.Errorf("malformed amount"))
+		return
+	}
+	if amnt.Cmp(&big.Int{}) <= 0 {
+		_ = level.Warn(w.logger).Log("msg", "requested amount is <= 0",
+			"amnt", amntStr,
+		)
+		sendErrorResponse(http.StatusBadRequest, fmt.Errorf("invalid amount"))
+		return
+	}
+
+	nonce := atomic.AddUint64(&w.nonce, 1)
+	tx := types.NewTransaction(nonce, to, &amnt, 21000, gasPrice, nil)
+	signedTx, err := types.SignTx(tx, types.HomesteadSigner{}, w.privateKey)
+	if err != nil {
+		_ = level.Warn(w.logger).Log("msg", "failed to sign transaction",
+			"err", err,
+		)
+		sendErrorResponse(http.StatusInternalServerError, err)
+		return
+	}
+
+	if err = w.client.SendTransaction(context.Background(), signedTx); err != nil {
+		_ = level.Warn(w.logger).Log("msg", "failed to send transaction",
+			"err", err,
+		)
+		sendErrorResponse(http.StatusInternalServerError, err)
+		return
+	}
+
+	_ = level.Info(w.logger).Log("msg", "private wallet funded",
+		"account", toStr,
+		"amount", amntStr,
+	)
+
+	resp.WriteHeader(http.StatusOK)
+}
+
+func parseHexAddress(s string) (common.Address, error) {
+	s = strings.TrimPrefix(strings.ToLower(s), "0x")
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		return common.Address{}, fmt.Errorf("failed to decode address: %v", err)
+	}
+	if len(b) != common.AddressLength {
+		return common.Address{}, fmt.Errorf("malformed address")
+	}
+
+	return common.BytesToAddress(b), nil
+}
+
+func runFaucetWorker(logger log.Logger) error {
+	if flagFaucetAddress == "" {
+		return fmt.Errorf("no faucet address specified")
+	}
+	if flagGatewayURL == "" {
+		return fmt.Errorf("no gateway URL specified")
+	}
+
+	w := &faucetWorker{
+		logger: log.With(logger, "module", "worker"),
+	}
+
+	gatewayURL, err := url.Parse(flagGatewayURL)
+	if err != nil {
+		return fmt.Errorf("failed to parse gateway URL: %v", err)
+	}
+	w.rpcClient, err = rpc.Dial(gatewayURL.String())
+	if err != nil {
+		return fmt.Errorf("failed to connect to gateway: %v", err)
+	}
+	w.client = ethclient.NewClient(w.rpcClient)
+	w.privateKey, err = crypto.HexToECDSA(transfer.FundingAccount)
+	if err != nil {
+		return fmt.Errorf("failed to decode funding address: %v", err)
+	}
+
+	_ = level.Info(w.logger).Log("msg", "initialized",
+		"gateway_url", gatewayURL,
+		"faucet_address", flagFaucetAddress,
+	)
+
+	http.HandleFunc("/", w.handleRequest)
+
+	return http.ListenAndServe(flagFaucetAddress, nil)
+}
+
+func faucetInit(debugCmd *cobra.Command) {
+	cmd := faucetCmd
+	cmd.Flags().StringVar(&flagFaucetAddress, cfgFaucetAddress, ":8080", "Lite faucet address")
+	cmd.Flags().StringVar(&flagGatewayURL, cfgGatewayURL, defaultGatewayURL, "JSON-RPC gateway URL")
+
+	for _, v := range []string{
+		cfgFaucetAddress,
+		cfgGatewayURL,
+	} {
+		_ = viper.BindPFlag(v, cmd.Flags().Lookup(v))
+	}
+
+	debugCmd.AddCommand(cmd)
+}


### PR DESCRIPTION
When ran, this runs a http server that uses funds from the test
environment genesis block to service requests made using the
`private-faucet` api.

I needed something to test the new txclient's private faucet support.  *shrug*