### PR TITLE
Temporary fix for jsonrpc/ws-rs incompatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,10 @@ benchmark = []
 [profile.release]
 panic = "abort"
 
+# temporary fix for incompatibility between jsonrpc and ws-rs
+[patch."https://github.com/tomusdrw/ws-rs"]
+ws = { git = "https://github.com/oasislabs/ws-rs", branch = "ekiden" }
+
 [patch.crates-io]
 ring = { git = "https://github.com/oasislabs/ring", branch = "0.12.1-ekiden" }
 


### PR DESCRIPTION
Temporary fix for #430 

Due to this unversioned dependency: https://github.com/paritytech/jsonrpc/blob/a1b2bb742ce16d1168669ffb13ffe856e8131228/ws/Cargo.toml#L18

We are pinning revision `f12d19c4c19422fc79af28a3181f598bc07ecd1e` as suggested here: https://github.com/paritytech/jsonrpc/issues/341#issuecomment-444941068