### PR TITLE
ci: use two backup compute replicas in end-to-end tests

### DIFF
--- a/scripts/test-basic-wasm.sh
+++ b/scripts/test-basic-wasm.sh
@@ -21,11 +21,8 @@ run_test() {
     run_keymanager_node
     sleep 1
     # Start compute nodes.
-    run_compute_node 1 --compute-replicas 2
+    run_compute_committee
     sleep 1
-    run_compute_node 2 --compute-replicas 2
-    sleep 1
-    run_compute_node 3 --compute-replicas 2
 
     run_gateway 1
     sleep 10

--- a/scripts/test-dapp.sh
+++ b/scripts/test-dapp.sh
@@ -20,11 +20,7 @@ run_test() {
     sleep 1
     run_keymanager_node
     sleep 1
-    run_compute_node 1 --compute-replicas 2
-    sleep 1
-    run_compute_node 2 --compute-replicas 2
-    sleep 1
-    run_compute_node 3 --compute-replicas 2
+    run_compute_committee
     sleep 1
     run_gateway 1
     sleep 1

--- a/scripts/test-e2e.sh
+++ b/scripts/test-e2e.sh
@@ -27,12 +27,8 @@ run_test() {
     sleep 1
 
     # Start compute nodes.
-    run_compute_node 1 --compute-replicas 2
+    run_compute_committee
     sleep 1
-    run_compute_node 2 --compute-replicas 2
-    sleep 1
-    run_compute_node 3 --compute-replicas 2
-
     # Advance epoch to elect a new committee.
     sleep 3
     ${WORKDIR}/ekiden-node debug dummy set-epoch --epoch 1

--- a/scripts/test-pubsub.sh
+++ b/scripts/test-pubsub.sh
@@ -16,12 +16,8 @@ run_test() {
     run_keymanager_node
     sleep 1
     # Start compute nodes.
-    run_compute_node 1 --compute-replicas 2
+    run_compute_committee
     sleep 1
-    run_compute_node 2 --compute-replicas 2
-    sleep 1
-    run_compute_node 3 --compute-replicas 2
-
     run_gateway 1
     sleep 10
 

--- a/scripts/test-rpc.sh
+++ b/scripts/test-rpc.sh
@@ -16,12 +16,8 @@ run_test() {
     run_keymanager_node
     sleep 1
     # Start compute nodes.
-    run_compute_node 1 --compute-replicas 2
+    run_compute_committee
     sleep 1
-    run_compute_node 2 --compute-replicas 2
-    sleep 1
-    run_compute_node 3 --compute-replicas 2
-
     run_gateway 1
     sleep 3
 
@@ -36,7 +32,7 @@ run_test() {
     cd rpc-tests
     git pull
     npm install > /dev/null
-    
+
     echo "Running RPC tests."
     ./run_tests.sh
 }

--- a/scripts/test-storage.sh
+++ b/scripts/test-storage.sh
@@ -21,12 +21,8 @@ run_test() {
     run_keymanager_node
     sleep 1
     # Start compute nodes.
-    run_compute_node 1 --compute-replicas 2
+    run_compute_committee
     sleep 1
-    run_compute_node 2 --compute-replicas 2
-    sleep 1
-    run_compute_node 3 --compute-replicas 2
-
     run_gateway 1
     sleep 10
 

--- a/scripts/test-web3cjs.sh
+++ b/scripts/test-web3cjs.sh
@@ -19,11 +19,7 @@ run_test() {
     sleep 1
     run_keymanager_node
     sleep 1
-    run_compute_node 1 --compute-replicas 2
-    sleep 1
-    run_compute_node 2 --compute-replicas 2
-    sleep 1
-    run_compute_node 3 --compute-replicas 2
+    run_compute_committee
     sleep 1
     run_gateway 1
     sleep 1

--- a/scripts/test_rust_logistic.sh
+++ b/scripts/test_rust_logistic.sh
@@ -21,12 +21,8 @@ run_test() {
     run_keymanager_node
     sleep 1
     # Start compute nodes.
-    run_compute_node 1 --compute-replicas 2
+    run_compute_committee
     sleep 1
-    run_compute_node 2 --compute-replicas 2
-    sleep 1
-    run_compute_node 3 --compute-replicas 2
-
     run_gateway 1
     sleep 10
 

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -59,6 +59,18 @@ run_compute_node() {
         ${WORKDIR}/target/enclave/runtime-ethereum.so &> compute${id}.log &
 }
 
+run_compute_committee() {
+    args="--compute-replicas 2 --compute-backup-replicas 2"
+    run_compute_node 1 $args
+    sleep 1
+    run_compute_node 2 $args
+    sleep 1
+    run_compute_node 3 $args
+    sleep 1
+    run_compute_node 4 $args
+    sleep 1
+}
+
 run_gateway() {
     local id=$1
 


### PR DESCRIPTION
Addresses https://github.com/oasislabs/runtime-ethereum/issues/461

I've verified the tests fail when non-determinism is added (via reverting https://github.com/oasislabs/runtime-ethereum/commit/19a745724c5a5ab2945f8cda0eb0096403220d33). Example failure: https://buildkite.com/oasislabs/runtime-ethereum/builds/448#_