### PR TITLE
log::set_max_level() to Info on batch start

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,7 @@ impl BatchHandler for EthereumBatchHandler {
     fn start_batch(&self, ctx: &mut RuntimeCallContext) {
         // Set max log level to Info (default: Trace) to reduce logger OCALLs.
         log::set_max_level(log::LevelFilter::Info);
-        
+
         // Obtain current root hash from the block header.
         let root_hash = ctx.header.state_root;
 


### PR DESCRIPTION
In order to reduce the number of OCALLs, set default logging level in enclave to Info. Depends on https://github.com/oasislabs/ekiden/pull/1282