### PR TITLE
Use unique nonces for web3c encryption

### DIFF
--- a/tests/contracts/Counter.sol
+++ b/tests/contracts/Counter.sol
@@ -13,4 +13,11 @@ contract Counter {
 	_counter += 1;
 	emit Incremented(_counter);
   }
+
+  function incrementCounterManyTimes(uint256 count) public {
+	for (uint256 i = 0; i < count; i++) {
+	  _counter += 1;
+	  emit Incremented(_counter);
+	}
+  }
 }

--- a/tests/test/utils.js
+++ b/tests/test/utils.js
@@ -57,10 +57,35 @@ async function makeRpc(method, params) {
   return JSON.parse(await request(options));
 }
 
+function fromHexStr(hexStr) {
+  return new Uint8Array(hexStr.match(/.{1,2}/g).map(byte => parseInt(byte, 16)));
+}
+
+/**
+ * Adds one to the byteArray, a Uint8Array.
+ */
+function incrementByteArray(byteArray) {
+  let carry = 1;
+  let byteIndex = byteArray.length - 1;
+  while (carry == 1) {
+	carry += byteArray[byteIndex];
+	byteArray[byteIndex] = (carry % 256);
+	carry /= 256;
+	byteIndex -= 1;
+	// We've overflowed and are done (result is all zeroes).
+	if (byteIndex == 0) {
+	  return byteArray;
+	}
+  }
+  return byteArray;
+}
+
 module.exports = {
   readArtifact,
   provider,
   fetchNonce,
+  fromHexStr,
+  incrementByteArray,
   makeRpc,
   makeConfidential,
   GAS_LIMIT,


### PR DESCRIPTION
Addresses https://github.com/oasislabs/runtime-ethereum/issues/453

Related/dependent changes:

- ekiden: https://github.com/oasislabs/ekiden/pull/1308
- parity: https://github.com/oasislabs/parity/pull/57

- [x] uses [Nonce struct](https://github.com/oasislabs/ekiden/pull/1308/files#diff-bb1963354a1c6b851a67be7a47c4c612R15) in the [ConfidentialCtx](https://github.com/oasislabs/runtime-ethereum/pull/492/files#diff-b3b2ce2c745dd3fd9dd805ae519d891fR30)
- [x] [integration test](https://github.com/oasislabs/runtime-ethereum/pull/492/files#diff-5acb726c60a3ab46ecfb872c15a8679dR54) ensuring nonce is properly incremented