### PR TITLE
gateway: Rename storage backend imports due to Ekiden changes

### DIFF
--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -75,7 +75,7 @@ ekiden-registry-client = { git = "https://github.com/oasislabs/ekiden", branch =
 ekiden-roothash-client = { git = "https://github.com/oasislabs/ekiden", branch = "master" }
 ekiden-scheduler-client = { git = "https://github.com/oasislabs/ekiden", branch = "master" }
 ekiden-storage-dummy = { git = "https://github.com/oasislabs/ekiden", branch = "master" }
-ekiden-storage-frontend = { git = "https://github.com/oasislabs/ekiden", branch = "master" }
+ekiden-storage-client = { git = "https://github.com/oasislabs/ekiden", branch = "master" }
 hex = "0.3"
 
 [features]

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -85,9 +85,9 @@ extern crate ekiden_rpc_client;
 extern crate ekiden_scheduler_client;
 extern crate ekiden_storage_base;
 #[cfg(test)]
-extern crate ekiden_storage_dummy;
+extern crate ekiden_storage_client;
 #[cfg(test)]
-extern crate ekiden_storage_frontend;
+extern crate ekiden_storage_dummy;
 extern crate ethereum_api;
 #[cfg(test)]
 extern crate grpcio;

--- a/gateway/src/test_helpers.rs
+++ b/gateway/src/test_helpers.rs
@@ -11,8 +11,8 @@ use ekiden_registry_client;
 use ekiden_roothash_client;
 use ekiden_scheduler_client;
 use ekiden_storage_base::{InsertOptions, StorageBackend};
+use ekiden_storage_client;
 use ekiden_storage_dummy::DummyStorageBackend;
-use ekiden_storage_frontend;
 use ethcore::encoded;
 use ethcore::ids::BlockId;
 use hex;
@@ -74,7 +74,7 @@ pub fn get_test_runtime_client() -> runtime_ethereum::Client {
     ekiden_scheduler_client::SchedulerClient::register(&mut known_components);
     ekiden_registry_client::EntityRegistryClient::register(&mut known_components);
     ekiden_roothash_client::RootHashClient::register(&mut known_components);
-    ekiden_storage_frontend::StorageClient::register(&mut known_components);
+    ekiden_storage_client::StorageClient::register(&mut known_components);
     let args = App::new("testing")
         .arg(
             Arg::with_name("grpc-threads")


### PR DESCRIPTION
Required after oasislabs/ekiden#1334.