### PR TITLE
get-docker-tag: always prefix tag with branch name

### DIFF
--- a/.buildkite/scripts/set_docker_tag_meta_data.sh
+++ b/.buildkite/scripts/set_docker_tag_meta_data.sh
@@ -27,7 +27,6 @@ set -euxo pipefail
 
 docker_tag=$(scripts/get-docker-tag.sh\
               ${BUILDKITE_BRANCH:-unknown_git_branch} \
-              ${BUILDKITE_COMMIT:-unknown_git_commit} \
               ${BUILDKITE_TAG}
             )
 

--- a/scripts/get-docker-tag.bats
+++ b/scripts/get-docker-tag.bats
@@ -14,31 +14,24 @@
   [[ "$output" =~ "\$1: unbound variable" ]]
 }
 
-@test "Provide only git_branch should error" {
+@test "Provide only git_branch should succeed" {
   run ./get-docker-tag.sh 'some_git_branch_name'
-  [ "$status" -eq 1 ]
-  [[ "$output" =~ "\$2: unbound variable" ]]
-}
-
-@test "Provide git_branch, git_commit_sha, and git_tag_name should succeed" {
-  run ./get-docker-tag.sh 'some_git_branch_name' 'some_git_commit_sha' 'some_git_tag_name'
   [ "$status" -eq 0 ]
 }
 
-@test "Provide branch(master) and tag: should use tag as prefix" {
-  run ./get-docker-tag.sh 'master' 'some_sha' 'some_tag_name'
+@test "Provide git_branch and git_tag_name should succeed" {
+  run ./get-docker-tag.sh 'some_git_branch_name' 'some_git_tag_name'
+  [ "$status" -eq 0 ]
+}
+
+@test "Provide branch and tag: should use tag as prefix" {
+  run ./get-docker-tag.sh 'master' 'some_tag_name'
   [ "$status" -eq 0 ]
   [[ "$output" =~ "some_tag_name-" ]]
 }
 
-@test "Provide branch(master) and no tag: should use master as prefix" {
-  run ./get-docker-tag.sh 'master' 'some_sha'
+@test "Provide branch and no tag: should use branch as prefix" {
+  run ./get-docker-tag.sh 'beta'
   [ "$status" -eq 0 ]
-  [[ "$output" =~ "master-" ]]
-}
-
-@test "Provide branch(non-master) and no tag: should use commit_sha" {
-  run ./get-docker-tag.sh 'non_master_branch' 'some_sha'
-  [ "$status" -eq 0 ]
-  [ "$output" = "some_sha" ]
+  [[ "$output" =~ "beta-" ]]
 }

--- a/scripts/get-docker-tag.sh
+++ b/scripts/get-docker-tag.sh
@@ -3,47 +3,40 @@
 # This is a build script to determine the value of the tag
 # to use when versioning the docker image.
 #
+# Tag will be in format of:
+#  | if git tag provided: <tag_name>-<date>
+#  | otherwise:           <branch_name>-<date>
+#
 # The value of the tag will be echo'd to stdout
 # so that the calling script can do something useful
 # with it. For example, make it available elsewhere
 # in the pipeline by saving it as an artifact/meta-data/etc.
 #
 # Usage:
-# get-docker-tag.sh [git_branch] [git_commit_sha] [git_tag]
+# get-docker-tag.sh [git_branch] [git_tag]
 ##
 
-# get-docker-tag $BUILDKITE_BRANCH $BUILDKITE_COMMIT $BUILDKITE_TAG
+# get-docker-tag $BUILDKITE_BRANCH $BUILDKITE_TAG
 
 set -euo pipefail
 
 git_branch_name=$1
-git_commit_sha=$2
-git_tag_name=${3:-NO_TAG_PROVIDED}
+git_tag_name=${2:-NO_TAG_PROVIDED}
 
 # TODO possibly change to more human readable format:
 #      YYYY-mm-dd-HH-MM-SS
 timestamp=`date +%Y%m%d%H%M%S` # YYYYmmddHHMMSS
 
-if [ ${git_branch_name} = "master" ]; then
-    # If the current branch IS master, then we
-    # use a special value as the tag for the docker image.
-
-    # Use the current git tag as a prefix if it is
-    # defined. If not, use "master" as a default.
-    if [ ${git_tag_name} = "NO_TAG_PROVIDED" ]; then
-      prefix="master"
-    else
-      prefix=${git_tag_name}
-    fi
-
-    # Concat prefix and timestamp.
-    docker_image_tag=${prefix}-${timestamp}
+# Use the current git tag as a prefix if it is
+# defined. If not, use "master" as a default.
+if [ ${git_tag_name} = "NO_TAG_PROVIDED" ]; then
+  prefix="${git_branch_name}"
 else
-    # If the current branch IS NOT master, then
-    # it is a pull request or feature branch.
-    # Use the git commit SHA1 as the tag for the docker image.
-    docker_image_tag=${git_commit_sha}
+  prefix=${git_tag_name}
 fi
+
+# Concat prefix and timestamp.
+docker_image_tag=${prefix}-${timestamp}
 
 # Echo the final tag value to stdout
 # so that the calling script can do


### PR DESCRIPTION
Fixes the issue that current `beta` branch releases don't use `<branch-name>-<date>` format.

Looking at recent [image tags](https://cloud.docker.com/u/oasislabs/repository/docker/oasislabs/ekiden-runtime-ethereum/tags) i don't think we need the special handling of branches & we can always tag image with `<branch-name>-<date>`, as nothing is really using the `git sha` flow. 

I think the `git sha`  flow was intended for the case where we would be building and publishing images in the PR step already, which we later decided not to do.

_(the other possible fix would be replacing the `if [ ${git_branch_name} = "master" ]` -> `if 'master' or 'beta'`)_