### PR TITLE
ci: use large agents in other docker build steps

### DIFF
--- a/.buildkite/deploy.pipeline.yml
+++ b/.buildkite/deploy.pipeline.yml
@@ -12,6 +12,8 @@ steps:
     command:
       - .buildkite/scripts/build_tag_push_deployment_image.sh
       - .buildkite/scripts/promote_deployment_image_to.sh staging
+    agents:
+      buildkite_agent_size: large
 
   - label: Update staging beta docker image tags (beta branch only)
     branches: beta
@@ -29,6 +31,8 @@ steps:
     env:
       SGX_MODE: HW
       DEPLOYMENT_VARIANT: hw
+    agents:
+      buildkite_agent_size: large
 
   - wait
 


### PR DESCRIPTION
now that we are developing on master, we'll be building docker images from it. use large CI agents for that, because it takes a lot of compilation.