### PR TITLE
ci: build hardware image on master

### DIFF
--- a/.buildkite/deploy.pipeline.yml
+++ b/.buildkite/deploy.pipeline.yml
@@ -23,11 +23,11 @@ steps:
     agents:
       buildkite_agent_size: large
 
-  - label: Update hardware staging beta docker image tags (beta branch only)
-    branches: beta
+  - label: Update hardware staging docker image tags (master branches only)
+    branches: master
     command:
       - .buildkite/scripts/build_tag_push_deployment_image.sh
-      - .buildkite/scripts/promote_deployment_image_to.sh staging-beta-hw
+      - .buildkite/scripts/promote_deployment_image_to.sh staging-hw
     env:
       SGX_MODE: HW
       DEPLOYMENT_VARIANT: hw
@@ -52,9 +52,9 @@ steps:
       commit: HEAD
       branch: master
 
-  - label: "Trigger hardware staging beta deployment (beta branch only)"
-    trigger: private-ops-deploy-ekiden-hardware-staging-beta
-    branches: beta
+  - label: "Trigger hardware staging deployment (master branches only)"
+    trigger: private-ops-deploy-ekiden-hardware-staging
+    branches: master
     build:
       message: "${BUILDKITE_MESSAGE}"
       commit: HEAD


### PR DESCRIPTION
now that the beta branch is no longer maintained

cross reference: https://github.com/oasislabs/private-ops/pull/823

tasks before merge:
- [x]  update pipeline name on buildkite website