### PR TITLE
return request id on error

### DIFF
--- a/gateway/src/middleware.rs
+++ b/gateway/src/middleware.rs
@@ -48,8 +48,8 @@ impl ErrGen for RateLimitedErrGen {
     }
 }
 
-/// given a single call it generates an error response
-/// from the error generator
+/// Given a single call it generates an error response
+/// from the error generator.
 fn generate_error_response_call(call: &rpc::Call, gen: &ErrGen) -> rpc::Output {
     match call {
         rpc::Call::MethodCall(method) => {
@@ -58,12 +58,12 @@ fn generate_error_response_call(call: &rpc::Call, gen: &ErrGen) -> rpc::Output {
         rpc::Call::Notification(notification) => {
             rpc::Output::from(Err(gen.generate()), rpc::Id::Null, notification.jsonrpc)
         }
-        rpc::Call::Invalid(id) => rpc::Output::from(Err(gen.generate()), invalid.id.clone(), None),
+        rpc::Call::Invalid(id) => rpc::Output::from(Err(gen.generate()), id.clone(), None),
     }
 }
 
-/// given a batch of rpc calls it generates the appropriate
-/// error for each of the calls
+/// Given a batch of rpc calls it generates the appropriate
+/// error for each of the calls.
 fn generate_error_response_calls(calls: &Vec<rpc::Call>, gen: &ErrGen) -> Vec<rpc::Output> {
     calls
         .iter()
@@ -71,7 +71,7 @@ fn generate_error_response_calls(calls: &Vec<rpc::Call>, gen: &ErrGen) -> Vec<rp
         .collect::<Vec<_>>()
 }
 
-/// given a request it generates an error response for that request
+/// Given a request it generates an error response for that request.
 fn generate_error_response(request: rpc::Request, gen: &ErrGen) -> rpc::FutureResponse {
     Box::new(rpc::futures::finished(Some(match request {
         rpc::Request::Single(call) => {


### PR DESCRIPTION
Right now when the gateway returns an error for batch size or rate limit, the response does not have the ID of the request, so the clients ignore the response because they do not know to which request it belongs to. This should fix the problem.