### PR TITLE
instrumnent ws session open/close

### DIFF
--- a/gateway/src/informant.rs
+++ b/gateway/src/informant.rs
@@ -110,7 +110,6 @@ impl RpcStats {
             .unwrap_or(0)
     }
 
-    #[cfg(test)]
     /// Returns number of open sessions
     pub fn sessions(&self) -> usize {
         self.sessions.read().len()

--- a/gateway/src/middleware.rs
+++ b/gateway/src/middleware.rs
@@ -183,12 +183,12 @@ impl WsStats {
 
 impl ws::SessionStats for WsStats {
     fn open_session(&self, id: ws::SessionId) {
-        measure_counter_inc!("ws_session_open");
+        measure_gauge!("ws_sessions", self.stats.sessions());
         self.stats.open_session(H256::from(id))
     }
 
     fn close_session(&self, id: ws::SessionId) {
-        measure_counter_inc!("ws_session_close");
+        measure_gauge!("ws_sessions", self.stats.sessions());
         self.stats.close_session(&H256::from(id))
     }
 }


### PR DESCRIPTION
ideally we'd probably measure actual number of opened ws sessions, but i think this might be useful already