### PR TITLE
Simplify installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ container with all the included tools. Follow instructions for installing ekiden
 
 To start the SGX development container:
 ```bash
-$ cargo ekiden shell
+cargo ekiden shell
 ```
 
 All the following commands should be run in the container and not on the host.
@@ -21,60 +21,35 @@ Until all Ekiden repositories are public, you need to configure your Git inside 
 to correctly authenticate against GitHub. The best way is to generate a personal authentication
 token on GitHub and use it as follows inside the container:
 ```bash
-$ git config --global credential.helper store
-$ git config --global credential.https://github.com.username <username>
-$ echo "https://<username>:<token>@github.com" > ~/.git-credentials
+git config --global credential.helper store
+git config --global credential.https://github.com.username <username>
+echo "https://<username>:<token>@github.com" > ~/.git-credentials
 ```
 
 ## Installing tools
 
-*In the future, these will already be part of the development container.*
-
-You should install the correct versions (e.g., the same that you build against in `Cargo.toml`)
-of the Ekiden binaries:
 ```bash
-$ cargo install --git https://github.com/oasislabs/ekiden --branch master ekiden-tools
-$ cargo install --git https://github.com/oasislabs/ekiden --branch master ekiden-worker
-$ cargo install --git https://github.com/oasislabs/ekiden --branch master ekiden-keymanager-node
+export EKIDEN_HOME=/ekiden
+git clone https://github.com/oasislabs/ekiden $EKIDEN_HOME
+cd $EKIDEN_HOME
+make
+export PATH=$EKIDEN_HOME/go/ekiden:$PATH
 ```
-
-If you later need to update them to a new version use the `--force` flag to update.
-
-You also need the Go node:
-```bash
-$ mkdir -p /go/src/github.com/oasislabs
-$ cd /go/src/github.com/oasislabs
-$ git clone https://github.com/oasislabs/ekiden
-$ cd ekiden/go
-$ make
-$ cd ekiden
-$ cp ekiden /go/bin/
-```
-**Note**: You need to be on Go v1.11 since this project uses [modules](https://github.com/golang/go/wiki/Modules), and the source must be built outside of the `GOPATH`. 
+**Note**: You need to be on Go v1.11 since this project uses [modules](https://github.com/golang/go/wiki/Modules), and the source must be built outside of the `GOPATH`.
 
 ## Building the runtime
 
-First build the keymanager enclave:
 ```bash
-$ cd /go/src/github.com/oasislabs/ekiden/key-manager/dummy/enclave
-$ cargo ekiden build-enclave --output-identity
+cargo ekiden build-enclave --output-identity
 ```
 
-This step is needed so that we can compile the keymanager's enclave identity statically into the runtime enclave upon initialization.
-
-Then, to build the runtime run:
-```bash
-$ KM_ENCLAVE_PATH=<ekiden-keymanager-trusted.so path> cargo ekiden build-enclave --output-identity
-```
-
-The built enclave will be stored under `target/enclave/runtime-ethereum.so`.
+The runtime enclave will be stored under `target/enclave/runtime-ethereum.so`.
 
 ## Building the web3 gateway
 
 The web3 gateway is located under `gateway` and it may be built using:
 ```bash
-$ cd gateway
-$ CARGO_TARGET_DIR=target-dir cargo build
+cd gateway && CARGO_TARGET_DIR=target-dir cargo build && cd -
 ```
 
 Note: the environment variable `CARGO_TARGET_DIR` is not necessary in order to compile the project, but when using docker as a build environment, pointing target-dir to a path that is not shared with a mounted volume improves significantly the build times. For example if the path `/code` is mounted on docker, setting `CARGO_TARGET_DIR=/target` should do the trick.
@@ -83,7 +58,7 @@ Note: the environment variable `CARGO_TARGET_DIR` is not necessary in order to c
 
 To start a validator committee, two compute nodes, and a single gateway running on port 8545:
 ```bash
-$ ./scripts/gateway.sh
+scripts/gateway.sh
 ```
 
 ## Benchmarking
@@ -97,14 +72,12 @@ The built enclave will be stored under `target_benchmark/enclave/runtime-ethereu
 
 Release builds of `gateway` and `genesis` are also used for benchmarking. To build, for each component:
 ```bash
-$ cd <component>
-$ cargo build --release
+cd <component> && cargo build --release
 ```
 
 The actual benchmark itself is written in Go.  To build the benchmark:
 ```bash
-$ cd benchmark
-$ make
+cd benchmark && make
 ```
 
 Some sample benchmark driver scripts are located in `scripts/benchmarks/`.

--- a/build.rs
+++ b/build.rs
@@ -14,10 +14,17 @@ fn main() {
 /// The runtime uses this to extract the key manager's MRENCLAVE at compile time
 /// via the use_key_manager_contract! macro.
 fn generate_km_enclave_identity() {
-    let km_enclave_path = env::var("KM_ENCLAVE_PATH").expect("Please define KM_ENCLAVE_PATH");
+    let km_enclave_path: std::path::PathBuf = [
+        &env::var("EKIDEN_HOME").expect("Please define EKIDEN_HOME"),
+        "target",
+        "enclave",
+        "ekiden-keymanager-trusted.so",
+    ]
+    .iter()
+    .collect();
     ekiden_tools::generate_mod("src/generated", &[]);
     ekiden_tools::generate_enclave_identity(
         "src/generated/ekiden-key-manager.identity",
-        &km_enclave_path,
+        km_enclave_path.to_str().unwrap(),
     );
 }

--- a/scripts/gateway.sh
+++ b/scripts/gateway.sh
@@ -5,9 +5,10 @@ WORKDIR=${1:-$(pwd)}
 source scripts/utils.sh
 
 # Paths to Go node and keymanager enclave, assuming they were built according to the README
-EKIDEN_NODE=/go/src/github.com/oasislabs/ekiden/go/ekiden/ekiden
-KM_MRENCLAVE=/go/src/github.com/oasislabs/ekiden/target/enclave/ekiden-keymanager-trusted.mrenclave
-KM_ENCLAVE=/go/src/github.com/oasislabs/ekiden/target/enclave/ekiden-keymanager-trusted.so
+EKIDEN_HOME=${EKIDEN_HOME:-/go/src/github.com/oasislabs/ekiden}
+EKIDEN_NODE=$EKIDEN_HOME/go/ekiden/ekiden
+KM_MRENCLAVE=$EKIDEN_HOME/target/enclave/ekiden-keymanager-trusted.mrenclave
+KM_ENCLAVE=$EKIDEN_HOME/target/enclave/ekiden-keymanager-trusted.so
 
 # Paths to ekiden binaries
 EKIDEN_WORKER=$(which ekiden-worker)


### PR DESCRIPTION
Ekiden is now easy enough to `make`, which makes the installation instructions in the README redundant.

This PR also introduces the `EKIDEN_HOME` variable to replace `KM_ENCLAVE_PATH` and a smattering of other variables that all point to the same general area.

Also, this PR removes leading `$`s in bash code blocks because they _severely_ impinge on the ability to copy+paste.