### PR TITLE
docker: add secret ballot example references

### DIFF
--- a/docker/all-in-one/README.md
+++ b/docker/all-in-one/README.md
@@ -96,6 +96,12 @@ You can import these accounts into MetaMask for use with DApps:
 
 ![](metamask-privatekey.png)
 
+### Develop DApps
+This image runs the key manager with an insecure built-in set of keys.
+To test confidential contracts, use the public key `0x9d41a874b80e39a40c9644e964f0e4f967100c91654bfd7666435fe906af060f` to verify the key manager's signatures.
+See the Secret Ballot example's [app.js](https://github.com/oasislabs/secret-ballot/blob/9dbdc82512db042ae37d55059c31eae3befe6e7b/app/javascripts/app.js#L155-L158) for how to configure web3c.js to use this key in a DApp.
+You can [try the Secret Ballot example with this key](https://cdn.oasiscloud.io/ballot/index.html?insecureTestingKeys=1) online.
+
 ### Stop the container
 Run
 


### PR DESCRIPTION
We've added a url parameter to the secret ballot frontend to switch in the unsecret testing key, which we use in the all-in-one image. so now there's a DApp that we can play with in the all-in-one image.