### PR TITLE
Set env vars in gateway.sh

### DIFF
--- a/scripts/gateway.sh
+++ b/scripts/gateway.sh
@@ -2,8 +2,6 @@
 
 WORKDIR=${1:-$(pwd)}
 
-source ${SCRIPTS_UTILS:-scripts/utils.sh}
-
 # Paths to Go node and keymanager enclave, assuming they were built according to the README
 : ${EKIDEN_NODE:=/go/src/github.com/oasislabs/ekiden/go/ekiden/ekiden}
 : ${KM_MRENCLAVE:=/go/src/github.com/oasislabs/ekiden/target/enclave/ekiden-keymanager-trusted.mrenclave}
@@ -12,6 +10,8 @@ source ${SCRIPTS_UTILS:-scripts/utils.sh}
 # Paths to ekiden binaries
 : ${EKIDEN_WORKER:=$(which ekiden-worker)}
 : ${KM_NODE:=$(which ekiden-keymanager-node)}
+
+source ${SCRIPTS_UTILS:-scripts/utils.sh}
 
 # Ensure cleanup on exit.
 # cleanup() is defined in scripts/utils.sh


### PR DESCRIPTION
Previously the values in `gateway.sh` were ignored as they were already set by `source scripts/utils.sh`.