### PR TITLE
Remove some unneeded stuff from setup-e2e.sh

### DIFF
--- a/scripts/setup-e2e.sh
+++ b/scripts/setup-e2e.sh
@@ -14,12 +14,6 @@ pushd /e2e-tests/ > /dev/null
 npm install
 popd > /dev/null
 
-echo "Installing wasm32-unknown-unknown target."
-rustup target add wasm32-unknown-unknown
-
-echo "Installing wscat."
-npm install -g wscat
-
 echo "Installing jq."
 apt-get install -y jq
 


### PR DESCRIPTION
`wscat` was used by the old pub/sub tests, which have been replaced.

`wasm32-unknown-unknown` shouldn't be needed anymore, as we download the pre-compiled contracts from `e2e-tests` buildkite.