### PR TITLE
Fix gateway.sh to run all services

### DIFF
--- a/.buildkite/scripts/common_e2e.sh
+++ b/.buildkite/scripts/common_e2e.sh
@@ -20,3 +20,32 @@ run_gateway() {
         --threads 100 \
         --ws-port ${ws_port} 2>&1 | tee ${EKIDEN_COMMITTEE_DIR}/gateway-$id.log | sed "s/^/[gateway-${id}] /" &
 }
+
+run_backend_tendermint_committee_custom() {
+    run_backend_tendermint_committee \
+        replica_group_size=3
+}
+
+run_no_client() {
+    :
+}
+
+scenario_basic() {
+    local runtime=$1
+
+    # Initialize compute nodes.
+    run_compute_node 1 ${runtime}
+    run_compute_node 2 ${runtime}
+    run_compute_node 3 ${runtime}
+    run_compute_node 4 ${runtime}
+
+    # Wait for all compute nodes to start.
+    wait_compute_nodes 4
+
+    # Advance epoch to elect a new committee.
+    set_epoch 1
+
+    # Initialize gateway.
+    run_gateway 1
+    sleep 3
+}

--- a/.buildkite/scripts/test_e2e.sh
+++ b/.buildkite/scripts/test_e2e.sh
@@ -38,37 +38,6 @@ source .buildkite/rust/common.sh
 nvm_script="${NVM_DIR:-${HOME}/.nvm}/nvm.sh"
 [ -s "${nvm_script}" ] && source "${nvm_script}"
 
-###################
-# Test definitions.
-###################
-run_backend_tendermint_committee_custom() {
-    run_backend_tendermint_committee \
-        replica_group_size=3
-}
-
-run_no_client() {
-    :
-}
-
-scenario_basic() {
-    local runtime=$1
-
-    # Initialize compute nodes.
-    run_compute_node 1 ${runtime}
-    run_compute_node 2 ${runtime}
-    run_compute_node 3 ${runtime}
-    run_compute_node 4 ${runtime}
-
-    # Wait for all compute nodes to start.
-    wait_compute_nodes 4
-
-    # Advance epoch to elect a new committee.
-    set_epoch 1
-
-    # Initialize gateway.
-    run_gateway 1
-    sleep 3
-}
 
 ###########
 # RPC tests

--- a/scripts/gateway.sh
+++ b/scripts/gateway.sh
@@ -2,24 +2,22 @@
 
 set -euo pipefail
 
+WORKDIR=$(pwd)
+
 # For automatic cleanup on exit.
 source .buildkite/scripts/common.sh
+source .e2e/ekiden_common_e2e.sh
+source .buildkite/scripts/common_e2e.sh
 
-config="$1"
-ekiden_node="${EKIDEN_ROOT_PATH}/go/ekiden/ekiden"
-web3_gateway="target/debug/gateway"
+scenario_run_gateway() {
+	scenario_basic runtime-ethereum
+	sleep infinity
+}
 
-# Prepare an empty node directory.
-data_dir="/tmp/runtime-ethereum-${config}"
-rm -rf "${data_dir}"
-cp -R "configs/${config}" "${data_dir}"
-chmod -R go-rwx "${data_dir}"
-
-# Start the Ekiden node.
-${ekiden_node} --config configs/${config}.yml 2>/dev/null &
-sleep 1
-
-# Start the gateway.
-${web3_gateway} \
-    --node-address "unix:${data_dir}/internal.sock" \
-    --runtime-id 0000000000000000000000000000000000000000000000000000000000000000
+run_test \
+    pre_init_hook=run_no_client \
+    scenario=scenario_run_gateway \
+    name="gateway.sh" \
+    backend_runner=run_backend_tendermint_committee_custom \
+    runtime=runtime-ethereum \
+    client_runner=run_no_client


### PR DESCRIPTION
Re-uses the existing testing utilities to run all the ekiden services. @kostko please let me know if there's a preferred way of doing this.