### PR TITLE
docker: correct ws port in all-in-one

### DIFF
--- a/docker/all-in-one/Dockerfile
+++ b/docker/all-in-one/Dockerfile
@@ -7,4 +7,4 @@ COPY configs/single_node /var/ekiden/all-in-one-sw
 COPY configs/single_node_sgx /var/ekiden/all-in-one-hw
 RUN chmod -R go-rwx /var/ekiden/all-in-one-sw /var/ekiden/all-in-one-hw
 
-EXPOSE 8545/tcp 8555/tcp
+EXPOSE 8545/tcp 8546/tcp

--- a/docker/all-in-one/README.md
+++ b/docker/all-in-one/README.md
@@ -45,7 +45,7 @@ docker run \
     --volume=/opt/oasis/ias-creds:/mnt/ias-creds \
     --device=/dev/isgx \
     --publish=127.0.0.1:8545:8545/tcp \
-    --publish=127.0.0.1:8555:8555/tcp \
+    --publish=127.0.0.1:8546:8546/tcp \
     oasislabs/gateway-all-in-one:staging-hw
 ```
 

--- a/docker/all-in-one/run-sw.sh
+++ b/docker/all-in-one/run-sw.sh
@@ -7,6 +7,6 @@ docker run \
     --security-opt=apparmor=unconfined \
     --security-opt=seccomp=unconfined \
     --publish=127.0.0.1:8545:8545/tcp \
-    --publish=127.0.0.1:8555:8555/tcp \
+    --publish=127.0.0.1:8546:8546/tcp \
     -e AIO_NOSGX=1 \
     local-aio:latest

--- a/docker/all-in-one/run.sh
+++ b/docker/all-in-one/run.sh
@@ -9,5 +9,5 @@ docker run \
     --volume="$PWD/../private-ops/untracked/ias-dev-creds:/mnt/ias-creds" \
     --device=/dev/isgx \
     --publish=127.0.0.1:8545:8545/tcp \
-    --publish=127.0.0.1:8555:8555/tcp \
+    --publish=127.0.0.1:8546:8546/tcp \
     local-aio:latest


### PR DESCRIPTION
this broke when we stopped using gateway.sh and thus stopped passing the flag to override the websocket port. it now listens on port 8546 