### PR TITLE
configs: updating ekiden single node configs

### DIFF
--- a/configs/single_node.yml
+++ b/configs/single_node.yml
@@ -27,11 +27,13 @@ grpc:
 
 # Worker configuration.
 worker:
-  backend: sandboxed
-  binary: .ekiden/target/debug/ekiden-runtime-loader
-  runtime:
-    id: "0000000000000000000000000000000000000000000000000000000000000000"
-    binary: .runtime/target/debug/runtime-ethereum
+  compute:
+    enabled: true
+    backend: sandboxed
+    runtime_loader: .ekiden/target/debug/ekiden-runtime-loader
+    runtime:
+      id: "0000000000000000000000000000000000000000000000000000000000000000"
+      binary: .runtime/target/debug/runtime-ethereum
   client:
     port: 9200
     addresses:
@@ -41,6 +43,7 @@ worker:
 
 # Key manager configuration.
 keymanager:
+  enabled: true
   loader: .ekiden/target/debug/ekiden-runtime-loader
   runtime: .ekiden/target/debug/ekiden-keymanager-runtime
   port: 9003

--- a/configs/single_node_sgx.yml
+++ b/configs/single_node_sgx.yml
@@ -27,13 +27,15 @@ grpc:
 
 # Worker configuration.
 worker:
-  backend: sandboxed
-  binary: .ekiden/target/debug/ekiden-runtime-loader
-  runtime:
-    id: "0000000000000000000000000000000000000000000000000000000000000000"
-    binary: .runtime/target/x86_64-fortanix-unknown-sgx/debug/runtime-ethereum.sgxs
-    sgx_ids:
-      - "0000000000000000000000000000000000000000000000000000000000000000"
+  compute:
+    enabled: true
+    backend: sandboxed
+    runtime_loader: .ekiden/target/debug/ekiden-runtime-loader
+    runtime:
+      id: "0000000000000000000000000000000000000000000000000000000000000000"
+      binary: .runtime/target/x86_64-fortanix-unknown-sgx/debug/runtime-ethereum.sgxs
+      sgx_ids:
+        - "0000000000000000000000000000000000000000000000000000000000000000"
   client:
     port: 9200
     addresses:
@@ -47,6 +49,7 @@ ias:
 
 # Key manager configuration.
 keymanager:
+  enabled: true
   tee_hardware: intel-sgx
   loader: .ekiden/target/debug/ekiden-runtime-loader
   runtime: .ekiden/target/x86_64-fortanix-unknown-sgx/debug/ekiden-keymanager-runtime.sgxs


### PR DESCRIPTION
Some ekiden args changed as part of: https://github.com/oasislabs/ekiden/pull/1634

This one looks pretty outdated, so not sure if should even fix it:
- https://github.com/oasislabs/runtime-ethereum/blob/master/scripts/utils.sh (and a bunch of scripts relaying on this one)