### PR TITLE
Revert "docker: update all-in-one configs for node roles"

### DIFF
--- a/docker/all-in-one/service/node/configs/all-in-one-hw.yml
+++ b/docker/all-in-one/service/node/configs/all-in-one-hw.yml
@@ -8,15 +8,13 @@ log:
     tendermint/context: error
 
 worker:
-  compute:
-    enabled: true
-    backend: sandboxed
-    runtime_loader: /ekiden/bin/ekiden-runtime-loader
-    runtime:
-      id: "0000000000000000000000000000000000000000000000000000000000000000"
-      binary: /ekiden/lib/runtime-ethereum.sgxs
-      sgx_ids:
-        - "0000000000000000000000000000000000000000000000000000000000000000"
+  backend: sandboxed
+  binary: /ekiden/bin/ekiden-runtime-loader
+  runtime:
+    id: "0000000000000000000000000000000000000000000000000000000000000000"
+    binary: /ekiden/lib/runtime-ethereum.sgxs
+    sgx_ids:
+      - "0000000000000000000000000000000000000000000000000000000000000000"
   client:
     port: 9200
     addresses:
@@ -28,7 +26,6 @@ ias:
   proxy_addr: 127.0.0.1:9001
 
 keymanager:
-  enabled: true
   tee_hardware: intel-sgx
   loader: /ekiden/bin/ekiden-runtime-loader
   runtime: /ekiden/lib/ekiden-keymanager-runtime.sgxs

--- a/docker/all-in-one/service/node/configs/all-in-one-sw.yml
+++ b/docker/all-in-one/service/node/configs/all-in-one-sw.yml
@@ -8,13 +8,11 @@ log:
     tendermint/context: error
 
 worker:
-  compute:
-    enabled: true
-    backend: sandboxed
-    runtime_loader: /ekiden/bin/ekiden-runtime-loader
-    runtime:
-      id: "0000000000000000000000000000000000000000000000000000000000000000"
-      binary: /ekiden/lib/runtime-ethereum
+  backend: sandboxed
+  binary: /ekiden/bin/ekiden-runtime-loader
+  runtime:
+    id: "0000000000000000000000000000000000000000000000000000000000000000"
+    binary: /ekiden/lib/runtime-ethereum
   client:
     port: 9200
     addresses:
@@ -23,7 +21,6 @@ worker:
     port: 9100
 
 keymanager:
-  enabled: true
   loader: /ekiden/bin/ekiden-runtime-loader
   runtime: /ekiden/lib/ekiden-keymanager-runtime
   port: 9003


### PR DESCRIPTION
Reverts oasislabs/runtime-ethereum#738

Let's do this later, when we promote the ekiden changes that require this.