### PR TITLE
docker: force pull all-in-one base image

### DIFF
--- a/docker/all-in-one/build.sh
+++ b/docker/all-in-one/build.sh
@@ -5,6 +5,7 @@ tar -c \
     docker/all-in-one/service \
     docker/all-in-one/Dockerfile \
 | docker build \
+    --pull \
     --file=docker/all-in-one/Dockerfile \
     --tag=local-aio:latest \
     -


### PR DESCRIPTION
this is the only mechanism in place to get the right base image

fixes #739