### PR TITLE
configs: enable storage in single node configs

### DIFF
--- a/.buildkite/scripts/test_e2e.sh
+++ b/.buildkite/scripts/test_e2e.sh
@@ -60,7 +60,7 @@ scenario_basic() {
     run_compute_node 4 ${runtime}
 
     # Wait for all compute nodes to start.
-    wait_compute_nodes 4
+    wait_nodes 5 # 4 + storage
 
     # Advance epoch to elect a new committee.
     set_epoch 1

--- a/configs/single_node.yml
+++ b/configs/single_node.yml
@@ -40,6 +40,8 @@ worker:
       - "127.0.0.1:9200"
   p2p:
     port: 9100
+  storage:
+    enabled: true
 
 # Key manager configuration.
 keymanager:

--- a/configs/single_node_sgx.yml
+++ b/configs/single_node_sgx.yml
@@ -42,6 +42,8 @@ worker:
       - "127.0.0.1:9200"
   p2p:
     port: 9100
+  storage:
+    enabled: true
 
 # IAS configuration.
 ias:

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -228,7 +228,7 @@ run_compute_committee() {
     run_compute_node 4 ${UTILS_COMPUTE_EXTRA_ARGS}
 
     # Wait for all nodes to register.
-    wait_compute_nodes 4
+    wait_nodes 5 # 4 + storage
 }
 
 run_gateway() {
@@ -267,18 +267,6 @@ run_keymanager_node() {
         --tls-key $KM_KEY \
         --storage-path ${storage_dir} \
         ${extra_args} &
-}
-
-# Wait for a number of compute nodes to register.
-#
-# Arguments:
-#   nodes - number of nodes to wait for
-wait_compute_nodes() {
-    local nodes=$1
-
-    ${EKIDEN_NODE} debug dummy wait-nodes \
-        --address unix:${EKIDEN_VALIDATOR_SOCKET} \
-        --nodes $nodes
 }
 
 # Set epoch.


### PR DESCRIPTION
This (should) fix the tests. 

Although nothing uses the storage client (as everything is in a single-node) there needs to be a storage node registered otherwise scheduler won't schedule the committee for the runtime (which requires one storage node).