### PR TITLE
run-gateway: wait for node registration instead of sleeping

### DIFF
--- a/scripts/gateway.sh
+++ b/scripts/gateway.sh
@@ -17,7 +17,11 @@ chmod -R go-rwx "${data_dir}"
 
 # Start the Ekiden node.
 ${ekiden_node} --config configs/${config}.yml &
-sleep 1
+
+# Wait for the node to be registered.
+${ekiden_node} debug dummy wait-nodes \
+    --address unix:${data_dir}/internal.sock \
+    --nodes 1
 
 # Start the gateway.
 ${web3_gateway} \


### PR DESCRIPTION
Same fix as https://github.com/oasislabs/ekiden/commit/15966ffb3f8aa7cc675c4b48c681855086add24c

~~CI isn't going to pass until https://github.com/oasislabs/runtime-ethereum/pull/735 is merged~~