### PR TITLE
Support for check-only variant of ethereum_transaction API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,6 +49,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_matches"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "atty"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -200,7 +205,7 @@ source = "git+https://github.com/paritytech/bn#67df95d06683b99d4308af20f9adc3149
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "crunchy 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2495,6 +2500,7 @@ dependencies = [
 name = "runtime-ethereum"
 version = "0.3.0"
 dependencies = [
+ "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "common-types 0.1.0 (git+https://github.com/oasislabs/parity?branch=ekiden-beta)",
@@ -3763,6 +3769,7 @@ dependencies = [
 "checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
 "checksum arrayvec 0.3.25 (registry+https://github.com/rust-lang/crates.io-index)" = "06f59fe10306bb78facd90d28c2038ad23ffaaefa85bac43c8a434cde383334f"
 "checksum arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "92c7fb76bc8826a8b33b4ee5bb07a247a81e76764ab4d55e8f73e3a4d8808c71"
+"checksum assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7deb0a829ca7bcfaf5da70b073a8d128619259a7be8216a355e23f00763059e5"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
 "checksum autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a6d640bee2da49f60a4068a7fae53acde8982514ab7bae8b8cea9e88cbcfd799"
 "checksum backtrace 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "56acb7e9c23cb8c3a1f51713695c552a81ee667d9fd060d1ef407908480b7174"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ slog = "2.4.1"
 ekiden-tools = { git = "https://github.com/oasislabs/ekiden", branch = "master" }
 
 [dev-dependencies]
+assert_matches = "1.3.0"
 time = "0.1"
 
 [features]

--- a/src/methods.rs
+++ b/src/methods.rs
@@ -1,5 +1,8 @@
 //! Methods exported to Ekiden clients.
-use ekiden_runtime::{runtime_context, transaction::Context as TxnContext};
+use ekiden_runtime::{
+    runtime_context,
+    transaction::{dispatcher::CheckOnlySuccess, Context as TxnContext},
+};
 use ethcore::{
     rlp,
     transaction::{SignedTransaction, UnverifiedTransaction},
@@ -52,6 +55,11 @@ pub mod execute {
     pub fn ethereum_transaction(tx: &Vec<u8>, ctx: &mut TxnContext) -> Fallible<ExecutionResult> {
         // Perform transaction checks.
         let tx = super::check::ethereum_transaction(tx, ctx)?;
+
+        // If this is a check txn request, return success.
+        if ctx.check_only {
+            return Err(CheckOnlySuccess.into());
+        }
 
         let ectx = runtime_context!(ctx, BlockContext);
 


### PR DESCRIPTION
As of https://github.com/oasislabs/ekiden/issues/1555, we have support for check-only variants of runtime calls. This PR implements a check-only variant of `ethereum_transaction`.