### PR TITLE
ci: Fix Rust coverage generation

### DIFF
--- a/.buildkite/rust/code_coverage.sh
+++ b/.buildkite/rust/code_coverage.sh
@@ -65,7 +65,7 @@ export RAYON_NUM_THREADS=1
 # Name the current commit so Tarpaulin can detect it correctly.
 git checkout -B ${BUILDKITE_BRANCH}
 
-# Calculate coverage
+# Calculate coverage.
 set +x
 cargo tarpaulin \
   --packages runtime-ethereum \


### PR DESCRIPTION
We are no longer using our tarpaulin fork which read git info from buildkite env vars. Now tarpaulin uses git to get this info.

Same fix as https://github.com/oasislabs/ekiden/pull/1770