### PR TITLE
Populate env_info.last_hashes with previous block hash

### DIFF
--- a/gateway/src/translator.rs
+++ b/gateway/src/translator.rs
@@ -243,8 +243,14 @@ impl Translator {
                         author: Default::default(),
                         timestamp: blk.snapshot.block.header.timestamp,
                         difficulty: Default::default(),
-                        // TODO: Get last hashes.
-                        last_hashes: Arc::new(vec![]),
+                        // TODO: Get 256 last hashes.
+                        last_hashes: Arc::new(vec![blk
+                            .snapshot
+                            .block
+                            .header
+                            .previous_hash
+                            .as_ref()
+                            .into()]),
                         gas_used: Default::default(),
                         gas_limit: U256::max_value(),
                     };

--- a/src/block.rs
+++ b/src/block.rs
@@ -63,8 +63,8 @@ impl BatchHandler for EthereumBatchHandler {
             timestamp: ctx.header.timestamp,
             difficulty: Default::default(),
             gas_limit: *genesis::GAS_LIMIT,
-            // TODO: Get last_hashes.
-            last_hashes: Arc::new(vec![]),
+            // TODO: Get 256 last_hashes.
+            last_hashes: Arc::new(vec![ctx.header.previous_hash.as_ref().into()]),
             gas_used: Default::default(),
         };
 


### PR DESCRIPTION
Toward https://github.com/oasislabs/runtime-ethereum/issues/745

For full compatibility with Ethereum, we would need to provide the hashes of the 256 most recent blocks. This data would need to be added to the ekiden transaction context.