### PR TITLE
Disable benchmarking flag in testing genesis block

### DIFF
--- a/resources/genesis/genesis_testing.json
+++ b/resources/genesis/genesis_testing.json
@@ -4,7 +4,6 @@
     "instantSeal": null
   },
   "params": {
-    "benchmarking": true,
     "gasLimitBoundDivisor": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
     "registrar" : "0xc6d9d2cd449a754c494264e1809c50e34d64562b",
     "accountStartNonce": "0x00",


### PR DESCRIPTION
The benchmarking flag disables nonce checking. Nonce checking should not be disabled for testing builds. We should build a separate benchmarking image with nonce checking disabled.