### PR TITLE
Fix production-genesis feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ confidential = []
 # Use test feature flag since Rust doesn't support conditional compilation using
 # cfg(test) on dependent crates.
 test = []
-production-genesis = []
+production-genesis = ["runtime-ethereum-common/production-genesis"]
 
 [profile.release]
 panic = "abort"

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -64,7 +64,7 @@ hex = "0.3"
 [features]
 default = ["pubsub"]
 pubsub = []
-production-genesis = []
+production-genesis = ["runtime-ethereum-common/production-genesis"]
 
 [[bin]]
 name = "gateway"


### PR DESCRIPTION
This was the cause of nonce checking being disabled on staging-beta (https://github.com/oasislabs/runtime-ethereum/issues/804).