### PR TITLE
ci: separate base image and deployment image variants

### DIFF
--- a/.buildkite/deploy.pipeline.yml
+++ b/.buildkite/deploy.pipeline.yml
@@ -42,7 +42,7 @@ steps:
     artifact_paths:
       - platform/*
     env:
-      DEPLOYMENT_VARIANT: beta
+      BASE_VARIANT: beta
 
   - label: Extract production-track platform resources (master branches only)
     branches: master
@@ -117,6 +117,7 @@ steps:
       - .buildkite/scripts/build_tag_push_deployment_image.sh context.tar.gz
       - .buildkite/scripts/promote_deployment_image_to.sh latest-testing
     env:
+      BASE_VARIANT: testing
       DEPLOYMENT_VARIANT: testing
 
   - label: Update testing docker image tags (beta branch only)
@@ -125,6 +126,7 @@ steps:
       - .buildkite/scripts/build_tag_push_deployment_image.sh context.tar.gz
       - .buildkite/scripts/promote_deployment_image_to.sh latest-testing-beta
     env:
+      BASE_VARIANT: testing
       DEPLOYMENT_VARIANT: testing
 
   - label: Update benchmarking docker image tags (master branches only)
@@ -133,6 +135,7 @@ steps:
       - .buildkite/scripts/build_tag_push_deployment_image.sh context-bench.tar.gz
       - .buildkite/scripts/promote_deployment_image_to.sh latest-benchmarking
     env:
+      BASE_VARIANT: testing
       DEPLOYMENT_VARIANT: benchmarking
 
   - label: Update benchmarking docker image tags (beta branch only)
@@ -141,6 +144,7 @@ steps:
       - .buildkite/scripts/build_tag_push_deployment_image.sh context-bench.tar.gz
       - .buildkite/scripts/promote_deployment_image_to.sh latest-benchmarking-beta
     env:
+      BASE_VARIANT: testing
       DEPLOYMENT_VARIANT: benchmarking
 
   - label: Update staging docker image tags (master branches only)
@@ -155,6 +159,7 @@ steps:
       - .buildkite/scripts/build_tag_push_deployment_image.sh context-prod.tar.gz
       - .buildkite/scripts/promote_deployment_image_to.sh staging-beta
     env:
+      BASE_VARIANT: beta
       DEPLOYMENT_VARIANT: beta
 
   - wait

--- a/.buildkite/scripts/build_tag_push_deployment_image.sh
+++ b/.buildkite/scripts/build_tag_push_deployment_image.sh
@@ -22,6 +22,7 @@ deployment_image_tag=$(buildkite-agent meta-data \
                        "deployment_image_tag"
                      )
 tag_suffix=${DEPLOYMENT_VARIANT:+-$DEPLOYMENT_VARIANT}
+base_tag_suffix=${BASE_VARIANT:+-$BASE_VARIANT}
 context=$1
 
 buildkite-agent artifact download "$context" .
@@ -30,4 +31,4 @@ docker/ekiden-runtime-ethereum/docker_build_and_push.sh \
   ${BUILDKITE_COMMIT} \
   ${deployment_image_tag}${tag_suffix} \
   "$context" \
-  latest${tag_suffix}
+  latest${base_tag_suffix}

--- a/.buildkite/scripts/extract_platform_resources.sh
+++ b/.buildkite/scripts/extract_platform_resources.sh
@@ -10,6 +10,6 @@
 set -euxo pipefail
 
 dst_dir=$1
-tag_suffix=${DEPLOYMENT_VARIANT:+-$DEPLOYMENT_VARIANT}
+tag_suffix=${BASE_VARIANT:+-$BASE_VARIANT}
 
 docker/ekiden-runtime-ethereum/extract_platform_resources.sh "$dst_dir" "latest$tag_suffix"


### PR DESCRIPTION
This allows us to have separate values for base image (`oasislabs/testnet`) variant and deployment image (`oasislabs/ekiden-runtime-ethereum`) variant. For example, we want to have a `benchmarking` variant of the deployment image based on the `testing` variant of the base image.