### PR TITLE
Move to devnet2 staging pipeline

### DIFF
--- a/.buildkite/deploy.pipeline.yml
+++ b/.buildkite/deploy.pipeline.yml
@@ -173,7 +173,7 @@ steps:
       branch: master
 
   - label: "Trigger staging beta deployment (beta branch only)"
-    trigger: private-ops-deploy-ekiden-staging-beta
+    trigger: private-ops-deploy-ekiden-devnet2-staging
     branches: beta
     build:
       message: "${BUILDKITE_MESSAGE}"


### PR DESCRIPTION
More changes should be made to this pipeline once we transition from maintaining beta as the "current" version. 

This will just make things work with the setup that is coming to private-ops.