### PR TITLE
Add staging-devnet2 promotion to production

### DIFF
--- a/.buildkite/deploy.production.pipeline.yml
+++ b/.buildkite/deploy.production.pipeline.yml
@@ -11,9 +11,16 @@ common_tools_plugin: &common_tools_plugin
   oasislabs/private-oasis-buildkite-tools#v0.2.0: ~
 
 steps:
-  - label: Update staging tag to be next-production-deployment (master branches only)
+  - label: Update staging devnet1 tag to be next-production-deployment (master branches only)
     branches: master
     command:
       - .buildkite/common/scripts/promote_docker_image_to.sh --from-image-tag staging oasislabs/ekiden-runtime-ethereum next-production-deployment
+    plugins:
+      - *common_tools_plugin
+
+  - label: Update staging devnet2 tag to be next-production-deployment (master branches only)
+    branches: master
+    command:
+      - .buildkite/common/scripts/promote_docker_image_to.sh --from-image-tag staging-devnet2 oasislabs/ekiden-runtime-ethereum next-production-devnet2-deployment
     plugins:
       - *common_tools_plugin


### PR DESCRIPTION
This should not be merged until we have updated to use the `staging-devnet2` docker tag instead of `staging-beta`.