### PR TITLE
buildkite/deploy: remove unexisting hwekiden reference

### DIFF
--- a/.buildkite/deploy.pipeline.yml
+++ b/.buildkite/deploy.pipeline.yml
@@ -171,14 +171,6 @@ steps:
       commit: HEAD
       branch: master
 
-  - label: "Trigger hardware staging deployment (master branches only)"
-    trigger: private-ops-deploy-ekiden-hardware-staging
-    branches: master
-    build:
-      message: "${BUILDKITE_MESSAGE}"
-      commit: HEAD
-      branch: master
-
   - label: "Build and push all-in-one image (master branches only)"
     branches: master
     command:


### PR DESCRIPTION
`hwekiden` doesn't exist anymore (it referred to the old ibm deploy)