### PR TITLE
Fix buildkite badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ekiden Ethereum runtime
 
-[![Build status](https://badge.buildkite.com/e1de50bd91d01f6aaf2b9fba113ad48b0118459d7d2c5dd2bd.svg)](https://buildkite.com/oasislabs/runtime-ethereum)
+[![Build status](https://badge.buildkite.com/e1de50bd91d01f6aaf2b9fba113ad48b0118459d7d2c5dd2bd.svg?branch=master)](https://buildkite.com/oasislabs/runtime-ethereum)
 [![Coverage Status](https://coveralls.io/repos/github/oasislabs/runtime-ethereum/badge.svg?branch=master&t=shmqoK)](https://coveralls.io/github/oasislabs/runtime-ethereum?branch=master)
 
 ## Setting up the development environment


### PR DESCRIPTION
Specify the branch name for the buildkite badge. Not clear what it refers to when no branch is specified.