### PR TITLE
benchmarking: fix benchmarking docker image build

### DIFF
--- a/.buildkite/benchmarking.pipeline.yml
+++ b/.buildkite/benchmarking.pipeline.yml
@@ -24,6 +24,7 @@ docker_plugin: &docker_plugin_configuration
       - "CARGO_TARGET_DIR=/workdir/target"
       - "CARGO_INSTALL_ROOT=/root/.cargo"
       - "RUSTFLAGS=-C target-feature=+aes,+ssse3"
+      - "GOPROXY=https://athens.ops.oasiscloud.io/"
     propagate-environment: true
     unconfined: true
 

--- a/docker/benchmarking/build_context.sh
+++ b/docker/benchmarking/build_context.sh
@@ -25,7 +25,7 @@ popd
 
 # Install cargo wasm32-unknown-unknown target and wasm build utilities.
 rustup target add wasm32-unknown-unknown
-cargo install owasm-utils-cli --bin wasm-build
+cargo install owasm-utils-cli --force --bin wasm-build
 apt install -y xxd
 
 # Compile genesis tool.


### PR DESCRIPTION
Fixes:  https://github.com/oasislabs/runtime-ethereum/issues/866

- using the goproxy fixes the daily benchmark build (looks like buildkite agents were getting rate limited)
- the force flag is useful locally when building the context (since `owasm-utils-cli` can already be installed)

See test run working: https://buildkite.com/oasislabs/runtime-ethereum-benchmarks/builds/143