### PR TITLE
genesis_playback: set io_root to empty hash

### DIFF
--- a/genesis/bin/genesis_playback.rs
+++ b/genesis/bin/genesis_playback.rs
@@ -304,6 +304,7 @@ fn main() {
     let mut block = roothash::Block::default();
     block.header.namespace = runtime_id;
     block.header.state_root = state_root;
+    block.header.io_root = Hash::empty_hash();
     let blocks = vec![block];
 
     // Save to file.


### PR DESCRIPTION
Part of: #893 

Fixes one of the errors during playback-benchmark