### PR TITLE
e2e-tests: detect panics on gateway

### DIFF
--- a/.buildkite/scripts/common_e2e.sh
+++ b/.buildkite/scripts/common_e2e.sh
@@ -19,3 +19,24 @@ run_gateway() {
         --http-port ${http_port} \
         --ws-port ${ws_port} 2>&1 | tee ${EKIDEN_COMMITTEE_DIR}/gateway-$id.log | sed "s/^/[gateway-${id}] /" &
 }
+
+_assert_gateway_logs_not_contain() {
+    set +ex
+    pattern=$1
+    msg=$2
+
+    grep -q "${pattern}" ${EKIDEN_COMMITTEE_DIR}/gateway-*.log
+    if [[ $? != "1" ]]; then
+        echo -e "\e[31;1mTEST ASSERTION FAILED: ${msg}\e[0m"
+        set -ex
+        exit 1
+    fi
+    set -ex
+}
+
+assert_basic_gw_success() {
+    assert_basic_success
+
+    # Assert no panic on gateway.
+    _assert_gateway_logs_not_contain "panicked at" "Panics detected during run."
+}

--- a/.buildkite/scripts/test_e2e.sh
+++ b/.buildkite/scripts/test_e2e.sh
@@ -195,7 +195,8 @@ test_suite() {
         name="e2e-${backend_name}-rpc-tests" \
         backend_runner=$backend_runner \
         runtime=runtime-ethereum \
-        client_runner=run_no_client
+        client_runner=run_no_client \
+        on_success_hook=assert_basic_gw_success
 
     # E2E tests from e2e-tests repository.
     run_test \
@@ -204,7 +205,8 @@ test_suite() {
         name="e2e-${backend_name}-e2e-tests" \
         backend_runner=$backend_runner \
         runtime=runtime-ethereum \
-        client_runner=run_no_client
+        client_runner=run_no_client \
+        on_success_hook=assert_basic_gw_success
 }
 
 ##########################################


### PR DESCRIPTION
Fixes: https://github.com/oasislabs/runtime-ethereum/issues/909

See: https://buildkite.com/oasislabs/runtime-ethereum/builds/2612#fc3add41-8486-407a-ae5d-e5a9a3b600c4 where end-to-end tests now properly fail. That test run contains this commit cherry-picked on top of https://github.com/oasislabs/runtime-ethereum/commit/ed810aa8dd11afaa1bd6bbab979569c122af894b where all tests passed before