### PR TITLE
RFC: remove `realpath` in symlink_artifacts

### DIFF
--- a/scripts/symlink_artifacts.sh
+++ b/scripts/symlink_artifacts.sh
@@ -21,7 +21,7 @@ symlink_artifact() {
     local root_path=$3
     local skip_sanity_check=${4:-"0"}
 
-    local artifact_src_path="$(realpath "${src_path}/${binary_path}")"
+    local artifact_src_path="$(realpath -m "${src_path}/${binary_path}")"
     local artifact_dst_path="${root_path}/${binary_path}"
 
     # Sanity check the source artifact.


### PR DESCRIPTION
symlink_artifacts is a script that we'd normally run when first setting up a checkout, before the first successful `make` invocation. In that state, you wouldn't have a `target/debug` directory yet, so realpath's requirement "all but the last component must exist" wouldn't be satisfied.

The subsequent work in symlink_artifacts, as the name suggests, is to create a symbolic link, so I think the links would still work. At runtime, the links will be followed to `target/debug`, and symlinks making up that path would further be resolved. This might even be nice in its own way, so that you could change target/debug without rerunning `make symlink-artifacts`.

I'm collecting developers' opinions on removing this `realpath` call. Please comment if this would break something you do.