### PR TITLE
ci: persist build artifacts in /var/tmp

### DIFF
--- a/.buildkite/benchmarking.pipeline.yml
+++ b/.buildkite/benchmarking.pipeline.yml
@@ -11,12 +11,12 @@ docker_plugin: &docker_plugin_configuration
       - /var/lib/buildkite-agent/.coveralls:/root/.coveralls
       - /var/lib/buildkite-agent/.buildkite:/root/.buildkite
       # Shared Rust target artifacts cache.
-      - /tmp/cargo_target:/cargo_target
+      - /var/tmp/cargo_target:/cargo_target
       # Shared Rust package checkouts directory.
-      - /tmp/cargo_pkg/git:/root/.cargo/git
-      - /tmp/cargo_pkg/registry:/root/.cargo/registry
+      - /var/tmp/cargo_pkg/git:/root/.cargo/git
+      - /var/tmp/cargo_pkg/registry:/root/.cargo/registry
       # Shared Rust SGX standard library artifacts cache.
-      - /tmp/xargo_cache:/root/.xargo
+      - /var/tmp/xargo_cache:/root/.xargo
     environment:
       - "LC_ALL=C.UTF-8"
       - "LANG=C.UTF-8"

--- a/.buildkite/deploy.pipeline.yml
+++ b/.buildkite/deploy.pipeline.yml
@@ -9,15 +9,15 @@ docker_plugin: &docker_plugin_configuration
     volumes:
       - .:/workdir
       # Shared Rust incremental compile caches.
-      - /tmp/cargo_ic/release:/workdir/target/release/incremental
-      - /tmp/cargo_ic/release_sgx:/workdir/target/x86_64-fortanix-unknown-sgx/release/incremental
+      - /var/tmp/cargo_ic/release:/workdir/target/release/incremental
+      - /var/tmp/cargo_ic/release_sgx:/workdir/target/x86_64-fortanix-unknown-sgx/release/incremental
       # Shared Rust package checkouts directory.
-      - /tmp/cargo_pkg/git:/root/.cargo/git
-      - /tmp/cargo_pkg/registry:/root/.cargo/registry
+      - /var/tmp/cargo_pkg/git:/root/.cargo/git
+      - /var/tmp/cargo_pkg/registry:/root/.cargo/registry
       # Shared Rust SGX standard library artifacts cache.
-      - /tmp/xargo_cache:/root/.xargo
+      - /var/tmp/xargo_cache:/root/.xargo
       # Shared Go package checkouts directory.
-      - /tmp/go_pkg:/root/go/pkg
+      - /var/tmp/go_pkg:/root/go/pkg
     environment:
       - "LC_ALL=C.UTF-8"
       - "LANG=C.UTF-8"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,15 +11,15 @@ docker_plugin: &docker_plugin_configuration
       - /var/lib/buildkite-agent/.coveralls:/root/.coveralls
       - /var/lib/buildkite-agent/.buildkite:/root/.buildkite
       # Shared Rust incremental compile caches.
-      - /tmp/cargo_ic/debug:/tmp/artifacts/debug/incremental
-      - /tmp/cargo_ic/debug_sgx:/tmp/artifacts/x86_64-fortanix-unknown-sgx/debug/incremental
+      - /var/tmp/cargo_ic/debug:/tmp/artifacts/debug/incremental
+      - /var/tmp/cargo_ic/debug_sgx:/tmp/artifacts/x86_64-fortanix-unknown-sgx/debug/incremental
       # Shared Rust package checkouts directory.
-      - /tmp/cargo_pkg/git:/root/.cargo/git
-      - /tmp/cargo_pkg/registry:/root/.cargo/registry
+      - /var/tmp/cargo_pkg/git:/root/.cargo/git
+      - /var/tmp/cargo_pkg/registry:/root/.cargo/registry
       # Shared Rust SGX standard library artifacts cache.
-      - /tmp/xargo_cache:/root/.xargo
+      - /var/tmp/xargo_cache:/root/.xargo
       # Shared Go package checkouts directory.
-      - /tmp/go_pkg:/root/go/pkg
+      - /var/tmp/go_pkg:/root/go/pkg
     environment:
       - "LC_ALL=C.UTF-8"
       - "LANG=C.UTF-8"


### PR DESCRIPTION
since /tmp will be put on /tmpfs on ci hosts, artifacts should be persisted through /var/tmp