### PR TITLE
Update build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For building and running the runtime, you need to have Oasis Core artifacts avai
 To do this, you can either:
 
 * Build Oasis Core locally by checking out the oasis-core repository (e.g., in `/path/to/oasis-core`)
-  and then running `OASIS_UNSAFE_SKIP_KM_POLICY=1 make -C /path/to/oasis-core`. After the
+  and then running `make -C /path/to/oasis-core`. After the
   process completes you can then run `make && make symlink-artifacts OASIS_CORE_SRC_PATH=/path/to/oasis-core`
   and all the required artifacts will be symlinked under `.oasis-core` and `.runtime`.
 

--- a/README.md
+++ b/README.md
@@ -31,11 +31,13 @@ To do this, you can either:
 In the following instructions, the top-level directory is the directory
 where the code has been checked out.
 
-## Building the runtime
+## Building the runtime (unsafe non-SGX environment)
 
 To build everything required for running the runtime, simply execute in the
 top-level directory:
 ```bash
+$ export OASIS_UNSAFE_SKIP_AVR_VERIFY="1"
+$ export OASIS_UNSAFE_SKIP_KM_POLICY="1"
 $ make
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To do this, you can either:
 
 * Build Oasis Core locally by checking out the oasis-core repository (e.g., in `/path/to/oasis-core`)
   and then running `make -C /path/to/oasis-core`. After the
-  process completes you can then run `make && make symlink-artifacts OASIS_CORE_SRC_PATH=/path/to/oasis-core`
+  process completes you can then run `make symlink-artifacts OASIS_CORE_SRC_PATH=/path/to/oasis-core`
   and all the required artifacts will be symlinked under `.oasis-core` and `.runtime`.
 
 * Download Oasis Core artifacts from a release (for currently supported release see `OASIS_CORE_VERSION` file),


### PR DESCRIPTION
Updated instructions and Makefile. Tested that the instructions from the current README work from a clean checkout of `oasis-runtime` and `oasis-core`.