### PR TITLE
Use correct runtime ID for KM client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,8 @@ check-tools:
 	)
 
 check-oasis-core:
-	@scripts/check_artifacts.sh
+	@export OASIS_CORE_ROOT_PATH=$(OASIS_CORE_ROOT_PATH) && \
+		scripts/check_artifacts.sh
 
 symlink-artifacts:
 	@$(ECHO) "$(CYAN)*** Symlinking Oasis Core and runtime build artifacts...$(OFF)"

--- a/bin/main.rs
+++ b/bin/main.rs
@@ -16,10 +16,8 @@ use std::sync::Arc;
 use serde_bytes::ByteBuf;
 
 use oasis_core_runtime::{
-    common::{runtime::RuntimeId, version::Version},
-    rak::RAK,
-    register_runtime_txn_methods, version_from_cargo, Protocol, RpcDemux, RpcDispatcher,
-    TxnDispatcher, TxnMethDispatcher,
+    common::version::Version, rak::RAK, register_runtime_txn_methods, version_from_cargo, Protocol,
+    RpcDemux, RpcDispatcher, TxnDispatcher, TxnMethDispatcher,
 };
 use oasis_runtime::block::OasisBatchHandler;
 use oasis_runtime_api::{with_api, ExecutionResult};

--- a/bin/main.rs
+++ b/bin/main.rs
@@ -39,8 +39,9 @@ fn main() {
         }
 
         // Create the key manager client.
+        let rt_id = protocol.get_runtime_id();
         let km_client = Arc::new(oasis_core_keymanager_client::RemoteClient::new_runtime(
-            RuntimeId::default(), // HACK: This is what's deployed.
+            rt_id,
             protocol.clone(),
             rak.clone(),
             1024, // TODO: How big should this cache be?

--- a/bin/main.rs
+++ b/bin/main.rs
@@ -37,9 +37,8 @@ fn main() {
         }
 
         // Create the key manager client.
-        let rt_id = protocol.get_runtime_id();
         let km_client = Arc::new(oasis_core_keymanager_client::RemoteClient::new_runtime(
-            rt_id,
+            protocol.get_runtime_id(),
             protocol.clone(),
             rak.clone(),
             1024, // TODO: How big should this cache be?


### PR DESCRIPTION
Previously we got away with hardcoded `RuntimeId::default()`, but now we're deploying the runtime with a non-zero ID.